### PR TITLE
Use explicit None checks for gate computation

### DIFF
--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -846,14 +846,12 @@ def reconstruct_all_ellipses(data, sd):
 def compute_v_gate_pxpf(v_gate_cms=None, px_per_cm=None, fps=None):
     try:
         if (
-            v_gate_cms
-            and px_per_cm
-            and fps
-            and v_gate_cms > 0
-            and px_per_cm > 0
-            and fps > 0
+            v_gate_cms is not None
+            and px_per_cm is not None
+            and fps is not None
         ):
-            return float(v_gate_cms * (px_per_cm / fps))
+            if v_gate_cms > 0 and px_per_cm > 0 and fps > 0:
+                return float(v_gate_cms * (px_per_cm / fps))
     except Exception:
         pass
     return None

--- a/tests/test_trackingutils.py
+++ b/tests/test_trackingutils.py
@@ -13,6 +13,13 @@ import pytest
 from deeplabcut.core import trackingutils
 
 
+def test_compute_v_gate_pxpf():
+    assert trackingutils.compute_v_gate_pxpf(1, 2, 4) == 0.5
+    assert trackingutils.compute_v_gate_pxpf(None, 2, 4) is None
+    assert trackingutils.compute_v_gate_pxpf(1, -2, 4) is None
+    assert trackingutils.compute_v_gate_pxpf(1, 2, 0) is None
+
+
 @pytest.fixture()
 def ellipse():
     params = {"x": 0, "y": 0, "width": 2, "height": 4, "theta": np.pi / 2}


### PR DESCRIPTION
## Summary
- replace truthy checks with explicit None checks and positive validation in compute_v_gate_pxpf
- add tests for compute_v_gate_pxpf

## Testing
- `pytest tests/test_trackingutils.py::test_compute_v_gate_pxpf -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0ccb49b8832291a0765c57205a62