### PR TITLE
Add CLI argument support for tracking scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,15 @@ importing a project into the new data format for DLC 2.0
 - July 2018: Ed Yong covered DeepLabCut and interviewed several users for the [Atlantic](https://www.theatlantic.com/science/archive/2018/07/deeplabcut-tracking-animal-movements/564338).
 - April 2018: first DeepLabCut preprint on [arXiv.org](https://arxiv.org/abs/1804.03142)
 
+## Command-line examples
+
+```bash
+python deeplabcut/newfolder/convert_detection2tracklets.py --config path/to/config.yaml --video-input path/to/video.mp4
+python deeplabcut/newfolder/match_rfid_to_tracklets.py --pickle-path tracklets.pickle --rfid-csv rfid.csv --centers-txt readers_centers.txt --ts-csv timestamps.csv
+python reconstruct_from_pickle.py --pickle-in tracklets.pickle --out-subdir CAP15
+python deeplabcut/newfolder/make_video.py --video-path video.mp4 --pickle-path tracklets.pickle --output-video output.mp4 --centers-txt readers_centers.txt --roi-file roi.json
+```
+
   ## Funding
 
   We are grateful for the follow support over the years! This software project was supported in part by the Essential Open Source Software for Science (EOSS) program at Chan Zuckerberg Initiative (cycles 1, 3, 3-DEI, 4), and jointly with the Kavli Foundation for EOSS Cycle 6!  We also thank the Rowland Institute at Harvard for funding from 2017-2020, and EPFL from 2020-present.

--- a/deeplabcut/newfolder/make_video.py
+++ b/deeplabcut/newfolder/make_video.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from collections import defaultdict, deque
 import cv2
 import numpy as np
+import argparse
 from utils import (
     load_tracklets_pickle, frame_idx_from_key, find_mouse_center_index,
     body_center_from_arr, color_for_id, parse_centers,
@@ -21,19 +22,19 @@ from utils import (
 )
 
 # ================== 配置参数 ==================
-# 文件路径
-VIDEO_PATH = "/ssd01/user_acc_data/oppa/deeplabcut/videos/test/demo.mp4"
-PICKLE_PATH = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/CAP15/demoDLC_HrnetW32_MiceTrackerFor20Dec8shuffle3_detector_best-250_snapshot_best-190_el.pickle"
+# 文件路径默认值
+DEFAULT_VIDEO_PATH = "/ssd01/user_acc_data/oppa/deeplabcut/videos/test/demo.mp4"
+DEFAULT_PICKLE_PATH = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/CAP15/demoDLC_HrnetW32_MiceTrackerFor20Dec8shuffle3_detector_best-250_snapshot_best-190_el.pickle"
 # 输出到指定文件夹
-OUTPUT_VIDEO = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/CAP15/demo_tracked.mp4"
+DEFAULT_OUTPUT_VIDEO = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/CAP15/demo_tracked.mp4"
 
 # 读卡器可视化
 DRAW_READERS = True
-CENTERS_TXT = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/readers_centers.txt"
+DEFAULT_CENTERS_TXT = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/readers_centers.txt"
 
 # ROI可视化
 DRAW_ROIS = True
-ROI_FILE = "/ssd01/user_acc_data/oppa/analysis/rfid_dlc_tracking/version2_tracking/roi_definitions.json"
+DEFAULT_ROI_FILE = "/ssd01/user_acc_data/oppa/analysis/rfid_dlc_tracking/version2_tracking/roi_definitions.json"
 
 # 轨迹参数
 PCUTOFF = 0.35                # 置信度阈值
@@ -54,6 +55,16 @@ LEGEND_POS = (20, 40)         # 图例位置
 
 # 输出限制
 MAX_FRAMES = None             # 最大输出帧数（None=全部）
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Visualize tracklets and RFID events on video")
+    parser.add_argument("--video-path", default=DEFAULT_VIDEO_PATH)
+    parser.add_argument("--pickle-path", default=DEFAULT_PICKLE_PATH)
+    parser.add_argument("--output-video", default=DEFAULT_OUTPUT_VIDEO)
+    parser.add_argument("--centers-txt", default=DEFAULT_CENTERS_TXT)
+    parser.add_argument("--roi-file", default=DEFAULT_ROI_FILE)
+    return parser.parse_args()
 
 # ================== 小工具 ==================
 def draw_label_with_bg(img, text, org, font_scale=0.6, thickness=2, fg=(255,255,255), bg=(0,0,0), alpha=0.4, padding=4):
@@ -266,15 +277,16 @@ def draw_chain_legend(frame, chain_trail, pos=(20, 40), cols=2):
 # ================== 主函数 ==================
 def main():
     """主函数"""
+    args = parse_args()
     # 检查文件是否存在
-    for pth, msg in [(VIDEO_PATH, "视频"), (PICKLE_PATH, "pickle")]:
+    for pth, msg in [(args.video_path, "视频"), (args.pickle_path, "pickle")]:
         if not Path(pth).exists():
             print(f"错误：{msg}文件不存在: {pth}")
             return
 
     # 加载数据
     print("正在加载tracklet数据...")
-    dd = load_tracklets_pickle(PICKLE_PATH)
+    dd = load_tracklets_pickle(args.pickle_path)
 
     print("构建每帧数据结构...")
     (frames_sorted, frame2tk_center, tk_rfid_events, tk_trail,
@@ -285,18 +297,18 @@ def main():
 
     # 加载读卡器位置（可选）
     reader_positions = None
-    if DRAW_READERS and Path(CENTERS_TXT).exists():
-        centers, meta = parse_centers(CENTERS_TXT)
+    if DRAW_READERS and Path(args.centers_txt).exists():
+        centers, meta = parse_centers(args.centers_txt)
         reader_positions = centers_to_reader_positions_column_major(centers, meta)
         print(f"读取到 {len(reader_positions)} 个读卡器位置")
 
     # 加载ROI（可选）
-    rois = load_rois(ROI_FILE) if (DRAW_ROIS and ROI_FILE and Path(ROI_FILE).exists()) else []
+    rois = load_rois(args.roi_file) if (DRAW_ROIS and args.roi_file and Path(args.roi_file).exists()) else []
     if rois:
         print(f"加载了 {len(rois)} 个ROI区域")
 
     # 打开视频
-    cap = cv2.VideoCapture(VIDEO_PATH)
+    cap = cv2.VideoCapture(args.video_path)
     if not cap.isOpened():
         print("错误：无法打开视频文件")
         return
@@ -309,7 +321,7 @@ def main():
 
     # 设置输出视频
     fourcc = cv2.VideoWriter_fourcc(*'mp4v')
-    out = cv2.VideoWriter(OUTPUT_VIDEO, fourcc, fps if fps > 0 else 25.0, (W, H))
+    out = cv2.VideoWriter(args.output_video, fourcc, fps if fps > 0 else 25.0, (W, H))
 
     max_frames = T if MAX_FRAMES is None else min(T, MAX_FRAMES)
     print(f"视频信息: {W}x{H}, {fps:.2f}fps, 共 {T} 帧；将输出 {max_frames} 帧")
@@ -359,7 +371,7 @@ def main():
     cap.release()
     out.release()
     cv2.destroyAllWindows()
-    print(f"[OK] 完成！输出视频: {OUTPUT_VIDEO}")
+    print(f"[OK] 完成！输出视频: {args.output_video}")
 
 if __name__ == "__main__":
     main()

--- a/deeplabcut/newfolder/match_rfid_to_tracklets.py
+++ b/deeplabcut/newfolder/match_rfid_to_tracklets.py
@@ -20,17 +20,24 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
+import argparse
 
 # ==========================
 # ====== 用户配置区 =========
 # ==========================
 
 # ---- 路径 ----
-PICKLE_PATH = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/demoDLC_HrnetW32_MiceTrackerFor20Dec8shuffle3_detector_best-250_snapshot_best-190_el.pickle"
-RFID_CSV    = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/rfid_data_20250813_055827.csv"
-CENTERS_TXT = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/readers_centers.txt"
-TS_CSV      = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/record_20250813_053913_timestamps.csv"
-OUT_DIR     = None  # None -> 与 pickle 同目录创建 rfid_match_outputs/
+DEFAULT_PICKLE_PATH = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/demoDLC_HrnetW32_MiceTrackerFor20Dec8shuffle3_detector_best-250_snapshot_best-190_el.pickle"
+DEFAULT_RFID_CSV    = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/rfid_data_20250813_055827.csv"
+DEFAULT_CENTERS_TXT = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/readers_centers.txt"
+DEFAULT_TS_CSV      = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/record_20250813_053913_timestamps.csv"
+DEFAULT_OUT_DIR     = None  # None -> 与 pickle 同目录创建 rfid_match_outputs/
+
+PICKLE_PATH = DEFAULT_PICKLE_PATH
+RFID_CSV = DEFAULT_RFID_CSV
+CENTERS_TXT = DEFAULT_CENTERS_TXT
+TS_CSV = DEFAULT_TS_CSV
+OUT_DIR = DEFAULT_OUT_DIR
 
 # ---- 阵列/网格配置（很关键）----
 N_ROWS  = 12           # 行数
@@ -68,6 +75,16 @@ LOWHITS_THRESHOLD         = 200
 # ==========================
 # ====== 工具函数 ===========
 # ==========================
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Match RFID events to tracklets")
+    parser.add_argument("--pickle-path", default=DEFAULT_PICKLE_PATH)
+    parser.add_argument("--rfid-csv", default=DEFAULT_RFID_CSV)
+    parser.add_argument("--centers-txt", default=DEFAULT_CENTERS_TXT)
+    parser.add_argument("--ts-csv", default=DEFAULT_TS_CSV)
+    parser.add_argument("--out-dir", default=DEFAULT_OUT_DIR)
+    return parser.parse_args()
 
 def ensure_out_dir(pickle_path: str) -> Path:
     out = Path(OUT_DIR) if OUT_DIR else (Path(pickle_path).parent / "rfid_match_outputs")
@@ -365,6 +382,14 @@ def assign_tag_for_one_tracklet(
 # ==========================
 
 def main():
+    args = parse_args()
+    global PICKLE_PATH, RFID_CSV, CENTERS_TXT, TS_CSV, OUT_DIR
+    PICKLE_PATH = args.pickle_path
+    RFID_CSV = args.rfid_csv
+    CENTERS_TXT = args.centers_txt
+    TS_CSV = args.ts_csv
+    OUT_DIR = args.out_dir
+
     out_dir = ensure_out_dir(PICKLE_PATH)
 
     # 1) 加载并按坐标重排为行优先网格

--- a/reconstruct_from_pickle.py
+++ b/reconstruct_from_pickle.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from collections import defaultdict
 from typing import Dict, Tuple, List, Any
 import time
+import argparse
 import numpy as np
 import pandas as pd
 
@@ -26,9 +27,9 @@ from utils import (
 
 # ================== 配置参数 ==================
 # 输入输出路径
-PICKLE_IN  = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/demoDLC_HrnetW32_MiceTrackerFor20Dec8shuffle3_detector_best-250_snapshot_best-190_el.pickle"
-PICKLE_OUT = None                # None=覆盖输入；或给出新路径
-OUT_SUBDIR = "CAP15"             # 输出到输入pickle同目录下的子目录；设 None 则不用子目录
+DEFAULT_PICKLE_IN  = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/demoDLC_HrnetW32_MiceTrackerFor20Dec8shuffle3_detector_best-250_snapshot_best-190_el.pickle"
+DEFAULT_PICKLE_OUT = None                # None=覆盖输入；或给出新路径
+DEFAULT_OUT_SUBDIR = "CAP15"             # 输出到输入pickle同目录下的子目录；设 None 则不用子目录
 
 # 相机与门控
 FPS        = 30.0                # 帧/秒
@@ -53,6 +54,14 @@ STOP_NEAR_ANCHOR = True
 RESET_PREVIOUS   = True          # 运行前清理旧的 chain_* 字段
 LOG_RUN_METADATA = True          # 记录本次运行参数（安全写法）
 
+
+# ================== 参数解析 ==================
+def parse_args():
+    parser = argparse.ArgumentParser(description="Reconstruct trajectories from pickle")
+    parser.add_argument("--pickle-in", default=DEFAULT_PICKLE_IN)
+    parser.add_argument("--pickle-out", default=DEFAULT_PICKLE_OUT)
+    parser.add_argument("--out-subdir", default=DEFAULT_OUT_SUBDIR)
+    return parser.parse_args()
 
 # ================== 工具函数 ==================
 def _euclid(a, b) -> float:
@@ -409,13 +418,14 @@ def reconstruct_by_timespeed_gate(dd: Dict):
 
 # ================== 运行入口 ==================
 def main():
-    p_in = Path(PICKLE_IN)
-    if OUT_SUBDIR:
-        out_dir = p_in.parent / OUT_SUBDIR
+    args = parse_args()
+    p_in = Path(args.pickle_in)
+    if args.out_subdir:
+        out_dir = p_in.parent / args.out_subdir
         out_dir.mkdir(parents=True, exist_ok=True)
         p_out = out_dir / p_in.name  # 保留原文件名
     else:
-        p_out = p_in if PICKLE_OUT is None else Path(PICKLE_OUT)
+        p_out = p_in if args.pickle_out is None else Path(args.pickle_out)
 
     if not p_in.exists():
         print(f"错误：输入文件不存在: {p_in}")


### PR DESCRIPTION
## Summary
- add argparse-based CLI options for convert_detection2tracklets, match_rfid_to_tracklets, reconstruct_from_pickle, and make_video
- expose path parameters as configurable arguments and add example commands to README

## Testing
- `python -m py_compile deeplabcut/newfolder/convert_detection2tracklets.py deeplabcut/newfolder/match_rfid_to_tracklets.py reconstruct_from_pickle.py deeplabcut/newfolder/make_video.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'deeplabcut')*

------
https://chatgpt.com/codex/tasks/task_e_68ad154147348322bd269e2d5eae8dee