### PR TITLE
feat: add CLI args for RFID tools

### DIFF
--- a/tools/rfid_pipeline/REAMD.md
+++ b/tools/rfid_pipeline/REAMD.md
@@ -50,8 +50,11 @@ project/
 
 ### 1. 轨迹重建
 ```bash
-# 修改 reconstruct_from_pickle.py 中的路径配置
-python reconstruct_from_pickle.py
+# 示例：指定输入/输出路径及关键参数
+python reconstruct_from_pickle.py \
+  --pickle-in path/to/tracklets.pickle \
+  --out-subdir CAP15 \
+  --fps 30 --px-per-cm 14 --v-gate-cms 80
 ```
 
 输出文件：
@@ -60,8 +63,11 @@ python reconstruct_from_pickle.py
 
 ### 2. 视频生成
 ```bash
-# 修改 make_video.py 中的路径配置
-python make_video.py
+# 示例：生成带叠加信息的视频
+python make_video.py \
+  --video-path path/to/video.mp4 \
+  --pickle-path path/to/tracklets.pickle \
+  --output-video rfid_tracklets_overlay.mp4
 ```
 
 输出文件：

--- a/tools/rfid_pipeline/convert_detection2tracklets.py
+++ b/tools/rfid_pipeline/convert_detection2tracklets.py
@@ -7,11 +7,12 @@
 """
 
 from pathlib import Path
+import argparse
 import deeplabcut as dlc
 from deeplabcut.utils import auxiliaryfunctions as aux
 
 # ===========================
-# 硬编码参数（按需修改）
+# 默认参数（可通过命令行覆盖）
 # ===========================
 CONFIG_PATH  = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/config.yaml"
 TRACK_METHOD = "ellipse"   # "ellipse" / "skeleton" / "box"
@@ -75,4 +76,20 @@ def main():
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert DLC detections to tracklets")
+    parser.add_argument("--config", default=CONFIG_PATH, help="路径到 config.yaml")
+    parser.add_argument("--track-method", default=TRACK_METHOD, help="tracking 方法")
+    parser.add_argument("--shuffle", type=int, default=SHUFFLE, help="shuffle 编号")
+    parser.add_argument("--destfolder", default=DESTFOLDER, help="输出目录")
+    parser.add_argument("--video-input", default=VIDEO_INPUT, help="视频文件或目录")
+    parser.add_argument("--videotype", default=VIDEOTYPE, help="目录模式下的视频后缀")
+    args = parser.parse_args()
+
+    CONFIG_PATH = args.config
+    TRACK_METHOD = args.track_method
+    SHUFFLE = args.shuffle
+    DESTFOLDER = args.destfolder
+    VIDEO_INPUT = args.video_input
+    VIDEOTYPE = args.videotype
+
     main()

--- a/tools/rfid_pipeline/make_video.py
+++ b/tools/rfid_pipeline/make_video.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import cv2
 import numpy as np
+import argparse
 from .utils import (
     body_center_from_arr,
     centers_to_reader_positions_column_major,
@@ -480,4 +481,46 @@ def main():
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Overlay tracklets and RFID events on video")
+    parser.add_argument("--video-path", default=VIDEO_PATH, help="原始视频路径")
+    parser.add_argument("--pickle-path", default=PICKLE_PATH, help="tracklets pickle 文件")
+    parser.add_argument("--output-video", default=OUTPUT_VIDEO, help="输出视频文件")
+    parser.add_argument("--draw-readers", type=int, default=int(DRAW_READERS), help="绘制读卡器(1/0)")
+    parser.add_argument("--centers-txt", default=CENTERS_TXT, help="读卡器坐标文件")
+    parser.add_argument("--draw-rois", type=int, default=int(DRAW_ROIS), help="绘制ROI(1/0)")
+    parser.add_argument("--roi-file", default=ROI_FILE, help="ROI定义文件")
+    parser.add_argument("--pcutoff", type=float, default=PCUTOFF, help="置信度阈值")
+    parser.add_argument("--trail-len", type=int, default=TRAIL_LEN, help="轨迹长度")
+    parser.add_argument("--tag-hold-frames", type=int, default=TAG_HOLD_FRAMES, help="RFID标签显示帧数")
+    parser.add_argument("--show-chain", type=int, default=int(SHOW_CHAIN), help="显示身份链(1/0)")
+    parser.add_argument("--chain-fallback-id", type=int, default=int(CHAIN_FALLBACK_ID), help="使用chain_id回退(1/0)")
+    parser.add_argument("--chain-trail-len", type=int, default=CHAIN_TRAIL_LEN)
+    parser.add_argument("--chain-line-thick", type=int, default=CHAIN_LINE_THICK)
+    parser.add_argument("--chain-point-r", type=int, default=CHAIN_POINT_R)
+    parser.add_argument("--draw-legend", type=int, default=int(DRAW_LEGEND), help="绘制图例(1/0)")
+    parser.add_argument("--legend-cols", type=int, default=LEGEND_COLS)
+    parser.add_argument("--legend-pos", nargs=2, type=int, default=LEGEND_POS)
+    parser.add_argument("--max-frames", type=int, default=MAX_FRAMES)
+    args = parser.parse_args()
+
+    VIDEO_PATH = args.video_path
+    PICKLE_PATH = args.pickle_path
+    OUTPUT_VIDEO = args.output_video
+    DRAW_READERS = bool(args.draw_readers)
+    CENTERS_TXT = args.centers_txt
+    DRAW_ROIS = bool(args.draw_rois)
+    ROI_FILE = args.roi_file
+    PCUTOFF = args.pcutoff
+    TRAIL_LEN = args.trail_len
+    TAG_HOLD_FRAMES = args.tag_hold_frames
+    SHOW_CHAIN = bool(args.show_chain)
+    CHAIN_FALLBACK_ID = bool(args.chain_fallback_id)
+    CHAIN_TRAIL_LEN = args.chain_trail_len
+    CHAIN_LINE_THICK = args.chain_line_thick
+    CHAIN_POINT_R = args.chain_point_r
+    DRAW_LEGEND = bool(args.draw_legend)
+    LEGEND_COLS = args.legend_cols
+    LEGEND_POS = tuple(args.legend_pos)
+    MAX_FRAMES = args.max_frames
+
     main()

--- a/tools/rfid_pipeline/match_rfid_to_tracklets.py
+++ b/tools/rfid_pipeline/match_rfid_to_tracklets.py
@@ -25,6 +25,7 @@ import json
 import pickle
 from pathlib import Path
 from collections import defaultdict
+import argparse
 
 import numpy as np
 import pandas as pd
@@ -36,7 +37,7 @@ from .utils import (
 )
 
 # ==========================
-# ====== 用户配置区 =========
+# ====== 默认参数 ==========
 # ==========================
 
 # ---- 路径 ----
@@ -653,4 +654,61 @@ def main():
     print(f"  pickle 已更新（backup: {backup_path}）")
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Match RFID events to tracklets")
+    parser.add_argument("--pickle-path", default=PICKLE_PATH, help="tracklets pickle 路径")
+    parser.add_argument("--rfid-csv", default=RFID_CSV, help="RFID 读数 CSV")
+    parser.add_argument("--centers-txt", default=CENTERS_TXT, help="读卡器坐标文件")
+    parser.add_argument("--ts-csv", default=TS_CSV, help="时间戳 CSV")
+    parser.add_argument("--out-dir", default=OUT_DIR, help="输出目录")
+    parser.add_argument("--n-rows", type=int, default=N_ROWS, help="读卡器行数")
+    parser.add_argument("--n-cols", type=int, default=N_COLS, help="读卡器列数")
+    parser.add_argument("--id-base", type=int, default=ID_BASE, help="RFID id 起始值")
+    parser.add_argument("--y-top-to-bottom", type=int, default=int(Y_TOP_TO_BOTTOM), help="y 方向是否自上而下 (1/0)")
+    parser.add_argument("--pcutoff", type=float, default=PCUTOFF, help="置信度阈值")
+    parser.add_argument("--rfid-frame-range", type=int, default=RFID_FRAME_RANGE, help="RFID 时间窗口")
+    parser.add_argument("--coil-diameter-px", type=float, default=COIL_DIAMETER_PX, help="线圈直径像素")
+    parser.add_argument("--hit-margin", type=float, default=HIT_MARGIN, help="命中半径倍率")
+    parser.add_argument("--unique-neighbor-only", type=int, default=int(UNIQUE_NEIGHBOR_ONLY), help="是否要求唯一最近邻(1/0)")
+    parser.add_argument("--ambig-margin-px", type=float, default=AMBIG_MARGIN_PX, help="模糊距离阈值")
+    parser.add_argument("--low-freq-tag-min-count", type=int, default=LOW_FREQ_TAG_MIN_COUNT, help="低频tag过滤阈值")
+    parser.add_argument("--min-valid-frames-per-tk", type=int, default=MIN_VALID_FRAMES_PER_TK, help="tracklet最少有效帧")
+    parser.add_argument("--tag-confidence-threshold", type=float, default=TAG_CONFIDENCE_THRESHOLD, help="标签占比阈值")
+    parser.add_argument("--tag-min-reads", type=int, default=TAG_MIN_READS, help="标签最少读数")
+    parser.add_argument("--tag-dominant-ratio", type=float, default=TAG_DOMINANT_RATIO, help="一二名占比")
+    parser.add_argument("--low-reads-high-purity-assign", type=int, default=int(LOW_READS_HIGH_PURITY_ASSIGN), help="低读数高纯度仍指派(1/0)")
+    parser.add_argument("--low-reads-purity-threshold", type=float, default=LOW_READS_PURITY_THRESHOLD, help="低读数纯度阈值")
+    parser.add_argument("--use-frame-stability-check", type=int, default=int(USE_FRAME_STABILITY_CHECK), help="逐帧稳健性检查(1/0)")
+    parser.add_argument("--burst-gap-frames", type=int, default=BURST_GAP_FRAMES, help="波段间隔帧数")
+    parser.add_argument("--min-bursts-if-lowhits", type=int, default=MIN_BURSTS_IF_LOWHITS, help="低读数最少波段数")
+    parser.add_argument("--lowhits-threshold", type=int, default=LOWHITS_THRESHOLD, help="低读数阈值")
+    args = parser.parse_args()
+
+    PICKLE_PATH = args.pickle_path
+    RFID_CSV = args.rfid_csv
+    CENTERS_TXT = args.centers_txt
+    TS_CSV = args.ts_csv
+    OUT_DIR = args.out_dir
+    N_ROWS = args.n_rows
+    N_COLS = args.n_cols
+    ID_BASE = args.id_base
+    Y_TOP_TO_BOTTOM = bool(args.y_top_to_bottom)
+    PCUTOFF = args.pcutoff
+    RFID_FRAME_RANGE = args.rfid_frame_range
+    COIL_DIAMETER_PX = args.coil_diameter_px
+    HIT_MARGIN = args.hit_margin
+    HIT_RADIUS_PX = (COIL_DIAMETER_PX / 2.0) * HIT_MARGIN
+    UNIQUE_NEIGHBOR_ONLY = bool(args.unique_neighbor_only)
+    AMBIG_MARGIN_PX = args.ambig_margin_px
+    LOW_FREQ_TAG_MIN_COUNT = args.low_freq_tag_min_count
+    MIN_VALID_FRAMES_PER_TK = args.min_valid_frames_per_tk
+    TAG_CONFIDENCE_THRESHOLD = args.tag_confidence_threshold
+    TAG_MIN_READS = args.tag_min_reads
+    TAG_DOMINANT_RATIO = args.tag_dominant_ratio
+    LOW_READS_HIGH_PURITY_ASSIGN = bool(args.low_reads_high_purity_assign)
+    LOW_READS_PURITY_THRESHOLD = args.low_reads_purity_threshold
+    USE_FRAME_STABILITY_CHECK = bool(args.use_frame_stability_check)
+    BURST_GAP_FRAMES = args.burst_gap_frames
+    MIN_BURSTS_IF_LOWHITS = args.min_bursts_if_lowhits
+    LOWHITS_THRESHOLD = args.lowhits_threshold
+
     main()

--- a/tools/rfid_pipeline/reconstruct_from_pickle.py
+++ b/tools/rfid_pipeline/reconstruct_from_pickle.py
@@ -26,6 +26,7 @@ from typing import Dict, Tuple, List, Any
 import time
 import numpy as np
 import pandas as pd
+import argparse
 
 from .utils import (
     load_tracklets_pickle,
@@ -35,7 +36,7 @@ from .utils import (
     body_center_from_arr,
 )
 
-# ================== 配置参数 ==================
+# ================== 默认参数 ==================
 # 输入输出路径
 PICKLE_IN  = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/demoDLC_HrnetW32_MiceTrackerFor20Dec8shuffle3_detector_best-250_snapshot_best-190_el.pickle"
 PICKLE_OUT = None                # None=覆盖输入；或给出新路径
@@ -489,4 +490,40 @@ def main():
     print(f"重建完成：共生成 {len(df_chains)} 条链段记录")
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Reconstruct tracklets with RFID anchors")
+    parser.add_argument("--pickle-in", default=PICKLE_IN, help="输入的 tracklets pickle")
+    parser.add_argument("--pickle-out", default=PICKLE_OUT, help="输出 pickle 文件路径")
+    parser.add_argument("--out-subdir", default=OUT_SUBDIR, help="输出子目录")
+    parser.add_argument("--fps", type=float, default=FPS, help="帧率")
+    parser.add_argument("--px-per-cm", type=float, default=PX_PER_CM, help="像素/厘米")
+    parser.add_argument("--v-gate-cms", type=float, default=V_GATE_CMS, help="速度门控(cm/s)")
+    parser.add_argument("--pcutoff", type=float, default=PCUTOFF, help="置信度阈值")
+    parser.add_argument("--head-tail-sample", type=int, default=HEAD_TAIL_SAMPLE, help="头尾采样帧数")
+    parser.add_argument("--max-gap-frames", type=int, default=MAX_GAP_FRAMES, help="最大时间间隔")
+    parser.add_argument("--anchor-min-hits", type=int, default=ANCHOR_MIN_HITS, help="锚点最少命中次数")
+    parser.add_argument("--eps-gap", type=float, default=EPS_GAP, help="代价中 gap 权重")
+    parser.add_argument("--delta-px-cap", type=float, default=DELTA_PX_CAP, help="歧义冻结像素上限")
+    parser.add_argument("--delta-prop", type=float, default=DELTA_PROP, help="歧义冻结相对门槛")
+    parser.add_argument("--stop-near-anchor", type=int, default=int(STOP_NEAR_ANCHOR), help="近锚点止水(1/0)")
+    parser.add_argument("--reset-previous", type=int, default=int(RESET_PREVIOUS), help="运行前清理旧链(1/0)")
+    parser.add_argument("--log-run-metadata", type=int, default=int(LOG_RUN_METADATA), help="记录运行参数(1/0)")
+    args = parser.parse_args()
+
+    PICKLE_IN = args.pickle_in
+    PICKLE_OUT = args.pickle_out
+    OUT_SUBDIR = args.out_subdir
+    FPS = args.fps
+    PX_PER_CM = args.px_per_cm
+    V_GATE_CMS = args.v_gate_cms
+    PCUTOFF = args.pcutoff
+    HEAD_TAIL_SAMPLE = args.head_tail_sample
+    MAX_GAP_FRAMES = args.max_gap_frames
+    ANCHOR_MIN_HITS = args.anchor_min_hits
+    EPS_GAP = args.eps_gap
+    DELTA_PX_CAP = args.delta_px_cap
+    DELTA_PROP = args.delta_prop
+    STOP_NEAR_ANCHOR = bool(args.stop_near_anchor)
+    RESET_PREVIOUS = bool(args.reset_previous)
+    LOG_RUN_METADATA = bool(args.log_run_metadata)
+
     main()


### PR DESCRIPTION
## Summary
- add argparse-powered CLI options to RFID pipeline scripts
- expose former constants such as config paths as command line arguments
- document new usage examples in `tools/rfid_pipeline/REAMD.md`

## Testing
- `pytest tests/test_video.py -q` *(fails: ModuleNotFoundError: No module named 'deeplabcut')*


------
https://chatgpt.com/codex/tasks/task_e_68ad4a0467b48322a1369028bf6f8677