### PR TITLE
Use MD5 hashing for deterministic RFID color generation

### DIFF
--- a/tools/rfid_pipeline/utils.py
+++ b/tools/rfid_pipeline/utils.py
@@ -4,6 +4,7 @@
 import json
 import math
 import re
+import hashlib
 import pickle
 from pathlib import Path
 from typing import List, Tuple, Dict, Any, Optional
@@ -92,7 +93,8 @@ def body_center_from_arr(arr: np.ndarray, mc_idx: Optional[int], pcutoff: float)
 
 def color_for_id(any_id) -> Tuple[int, int, int]:
     """为ID生成BGR颜色"""
-    h = abs(hash(str(any_id))) % 360
+    digest = hashlib.md5(str(any_id).encode("utf-8")).hexdigest()
+    h = int(digest, 16) % 360
     s, v = 0.8, 1.0
     c = v * s
     x = c * (1 - abs((h / 60) % 2 - 1))


### PR DESCRIPTION
## Summary
- derive hue from a deterministic MD5 hash of the ID
- keep existing HSV to BGR conversion logic for color

## Testing
- `pytest tools/rfid_pipeline/utils.py` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4a04ca7c8322838f3c37ff3405db