### PR TITLE
Include RFID pipeline as package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,8 @@ setuptools.setup(
         "wandb": ["wandb"],
     },
     scripts=["deeplabcut/pose_estimation_tensorflow/models/pretrained/download.sh"],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages() + setuptools.find_packages(where="tools"),
+    package_dir={"rfid_pipeline": "tools/rfid_pipeline"},
     data_files=[
         (
             "deeplabcut",
@@ -136,8 +137,15 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
         "Operating System :: OS Independent",
     ],
-    entry_points="""[console_scripts]
-            dlc=deeplabcut.__main__:main""",
+    entry_points={
+        "console_scripts": ["dlc=deeplabcut.__main__:main"],
+        "rfid_pipeline": [
+            "convert_detection2tracklets=rfid_pipeline.convert_detection2tracklets:main",
+            "match_rfid_to_tracklets=rfid_pipeline.match_rfid_to_tracklets:main",
+            "make_video=rfid_pipeline.make_video:main",
+            "reconstruct_from_pickle=rfid_pipeline.reconstruct_from_pickle:main",
+        ],
+    },
 )
 
 # https://www.python.org/dev/peps/pep-0440/#compatible-release

--- a/tools/rfid_pipeline/make_video.py
+++ b/tools/rfid_pipeline/make_video.py
@@ -10,13 +10,6 @@
 
 from __future__ import annotations
 
-if __name__ == "__main__" and __package__ is None:
-    import sys
-    from pathlib import Path
-
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
-    __package__ = "rfid_pipeline"
-
 from collections import defaultdict, deque
 from pathlib import Path
 

--- a/tools/rfid_pipeline/match_rfid_to_tracklets.py
+++ b/tools/rfid_pipeline/match_rfid_to_tracklets.py
@@ -12,13 +12,6 @@ RFID（按坐标重排→行优先 id）→ tracklet 累计读数 + 保守/智�
 
 from __future__ import annotations
 
-if __name__ == "__main__" and __package__ is None:
-    import sys
-    from pathlib import Path
-
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
-    __package__ = "rfid_pipeline"
-
 import os
 import re
 import json

--- a/tools/rfid_pipeline/reconstruct_from_pickle.py
+++ b/tools/rfid_pipeline/reconstruct_from_pickle.py
@@ -13,13 +13,6 @@
 
 from __future__ import annotations
 
-if __name__ == "__main__" and __package__ is None:
-    import sys
-    from pathlib import Path
-
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
-    __package__ = "rfid_pipeline"
-
 from pathlib import Path
 from collections import defaultdict
 from typing import Dict, Tuple, List, Any


### PR DESCRIPTION
## Summary
- package `tools/rfid_pipeline` for installation
- expose RFID pipeline utilities via new entry points
- drop manual `sys.path` tweaks in RFID scripts

## Testing
- `python -m compileall tools/rfid_pipeline`
- `python -m pip install -e .`
- `pytest tools/rfid_pipeline`
- `python - <<'PY'
import rfid_pipeline
import rfid_pipeline.make_video
import rfid_pipeline.match_rfid_to_tracklets
import rfid_pipeline.reconstruct_from_pickle
print('imported', rfid_pipeline.__file__)
PY` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4a06de708322a7eaadfaabaadd2b