### PR TITLE
Add CLI-based config for RFID tracklet conversion

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -6,11 +6,13 @@
 
 ```
 project/
-├── utils.py                      # 核心工具函数库
-├── reconstruct_from_pickle.py    # 轨迹重建脚本
-├── make_video.py                 # 视频可视化脚本
-├── roi_definitions.json          # ROI区域定义文件
-└── README.md                     # 项目说明
+├── utils.py                              # 核心工具函数库
+├── convert_detection2tracklets.py        # 检测结果转 tracklets
+├── convert_detection2tracklets_config.yaml  # 默认参数
+├── reconstruct_from_pickle.py            # 轨迹重建脚本
+├── make_video.py                         # 视频可视化脚本
+├── roi_definitions.json                  # ROI区域定义文件
+└── README.md                             # 项目说明
 ```
 
 ## 功能概述
@@ -47,6 +49,18 @@ project/
 - **几何计算**：ROI命中测试、距离计算
 
 ## 使用方法
+
+### 0. 检测结果转 tracklets
+```bash
+# 如需修改默认参数，先编辑 convert_detection2tracklets_config.yaml
+python convert_detection2tracklets.py --config-path <项目config.yaml> --video-input <视频或目录>
+```
+
+常用选项：
+- `--track-method`：`ellipse` / `skeleton` / `box`
+- `--shuffle`：训练 shuffle 编号
+- `--destfolder`：输出目录（默认跟随视频路径）
+- `--videotype`：目录模式下的视频后缀
 
 ### 1. 轨迹重建
 ```bash

--- a/deeplabcut/rfid_tracking/convert_detection2tracklets.py
+++ b/deeplabcut/rfid_tracking/convert_detection2tracklets.py
@@ -7,50 +7,72 @@
 """
 
 from pathlib import Path
+from typing import Optional
+
+import click
 import deeplabcut as dlc
 from deeplabcut.utils import auxiliaryfunctions as aux
 
-# ===========================
-# 硬编码参数（按需修改）
-# ===========================
-CONFIG_PATH  = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/config.yaml"
-TRACK_METHOD = "ellipse"   # "ellipse" / "skeleton" / "box"
-SHUFFLE      = 3
-DESTFOLDER   = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/"
-VIDEO_INPUT  = "/ssd01/user_acc_data/oppa/deeplabcut/videos/test/demo.mp4"
-VIDEOTYPE    = "mp4"       # 目录模式生效；文件模式无所谓
-# ===========================
+DEFAULTS_PATH = Path(__file__).with_name("convert_detection2tracklets_config.yaml")
 
 
-def collect_videos(input_path: str):
+def collect_videos(input_path: str, videotype: Optional[str]):
     p = Path(input_path)
     if p.is_dir():
-        if VIDEOTYPE:
-            vids = sorted(str(x) for x in p.glob(f"*.{VIDEOTYPE.lstrip('.')}"))
+        if videotype:
+            vids = sorted(str(x) for x in p.glob(f"*.{videotype.lstrip('.')}"))
         else:
             exts = (".mp4", ".avi", ".mov", ".mpeg", ".mkv")
             vids = sorted(str(x) for x in p.iterdir() if x.suffix.lower() in exts)
     else:
         vids = [str(p)]
     if not vids:
-        raise FileNotFoundError(f"在 {input_path} 下未找到视频（后缀：{VIDEOTYPE or '常见扩展'}）")
+        raise FileNotFoundError(
+            f"在 {input_path} 下未找到视频（后缀：{videotype or '常见扩展'}）"
+        )
     return vids
 
 
-def main():
-    videos = collect_videos(VIDEO_INPUT)
-    print(f"[INFO] config: {CONFIG_PATH}")
-    print(f"[INFO] videos: {len(videos)} 个（track_method={TRACK_METHOD}）")
-    print(f"[INFO] destfolder: {DESTFOLDER or '(视频目录)'}")
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--config-path", type=click.Path(exists=True, dir_okay=False), help="项目 config.yaml 路径")
+@click.option("--track-method", type=click.Choice(["ellipse", "skeleton", "box"]), help="tracklet 匹配方法")
+@click.option("--shuffle", type=int, help="训练 shuffle 编号")
+@click.option("--destfolder", type=click.Path(), help="输出目录")
+@click.option("--video-input", type=click.Path(), help="视频文件或目录")
+@click.option("--videotype", help="目录模式下的视频后缀")
+@click.option(
+    "--defaults",
+    type=click.Path(exists=True, dir_okay=False),
+    default=DEFAULTS_PATH,
+    show_default=True,
+    help="默认参数 YAML 文件",
+)
+def main(config_path, track_method, shuffle, destfolder, video_input, videotype, defaults):
+    defaults_dict = {}
+    if defaults and Path(defaults).is_file():
+        defaults_dict = aux.read_config(defaults)
 
-    # 1) 优先使用项目 config.yaml 中的 inference_cfg / inferencecfg
+    config_path = config_path or defaults_dict.get("config_path")
+    track_method = track_method or defaults_dict.get("track_method", "ellipse")
+    shuffle = shuffle or defaults_dict.get("shuffle", 1)
+    destfolder = destfolder or defaults_dict.get("destfolder")
+    video_input = video_input or defaults_dict.get("video_input")
+    videotype = videotype or defaults_dict.get("videotype")
+
+    if not config_path or not video_input:
+        raise click.UsageError("必须指定 CONFIG_PATH 和 VIDEO_INPUT（可在默认配置文件中设置）。")
+
+    videos = collect_videos(video_input, videotype)
+    print(f"[INFO] config: {config_path}")
+    print(f"[INFO] videos: {len(videos)} 个（track_method={track_method}）")
+    print(f"[INFO] destfolder: {destfolder or '(视频目录)'}")
+
     try:
-        cfg = aux.read_config(CONFIG_PATH)
+        cfg = aux.read_config(config_path)
         base_inferencecfg = (cfg.get("inference_cfg") or cfg.get("inferencecfg") or {}).copy()
     except Exception:
         base_inferencecfg = {}
 
-    # 2) 如果项目中没有，就提供 DLC 需要的“最小键”。不额外覆盖其它阈值，让 DLC 用默认。
     if not base_inferencecfg:
         base_inferencecfg = {
             "variant": "paf",                # 组装方式（常见）
@@ -60,15 +82,14 @@ def main():
             "withid": False,                 # 若关键点含 identity 通道才需 True；一般 False
         }
 
-    # 3) 调用 DLC：不再强行覆盖任何 tracking 阈值，保持默认
     dlc.convert_detections2tracklets(
-        config=CONFIG_PATH,
+        config=config_path,
         videos=videos,
-        videotype=VIDEOTYPE,
-        shuffle=SHUFFLE,
-        track_method=TRACK_METHOD,
-        destfolder=DESTFOLDER,
-        inferencecfg=base_inferencecfg
+        videotype=videotype,
+        shuffle=shuffle,
+        track_method=track_method,
+        destfolder=destfolder,
+        inferencecfg=base_inferencecfg,
     )
 
     print("\n[OK] 完成。请在对应输出目录查看 *.pickle（tracklets）文件。")

--- a/deeplabcut/rfid_tracking/convert_detection2tracklets_config.yaml
+++ b/deeplabcut/rfid_tracking/convert_detection2tracklets_config.yaml
@@ -1,0 +1,6 @@
+config_path: ""
+track_method: "ellipse"
+shuffle: 1
+destfolder: ""
+video_input: ""
+videotype: "mp4"


### PR DESCRIPTION
## Summary
- expose convert-detection-to-tracklets parameters via a Click CLI
- load defaults from new YAML config file using `aux.read_config`
- document command usage in RFID tracking README

## Testing
- `pytest -q deeplabcut/rfid_tracking`


------
https://chatgpt.com/codex/tasks/task_e_68ad82843e3483228eb99f16c3081106