### PR TITLE
feat: centralize RFID tracking configuration

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -9,6 +9,7 @@ project/
 ├── utils.py                              # 核心工具函数库
 ├── convert_detection2tracklets.py        # 检测结果转 tracklets
 ├── convert_detection2tracklets_config.yaml  # 默认参数
+├── config.py                             # 默认路径与门控参数
 ├── reconstruct_from_pickle.py            # 轨迹重建脚本
 ├── make_video.py                         # 视频可视化脚本
 ├── roi_definitions.json                  # ROI区域定义文件
@@ -64,7 +65,7 @@ python convert_detection2tracklets.py --config-path <项目config.yaml> --video-
 
 ### 1. 轨迹重建
 ```bash
-# 修改 reconstruct_from_pickle.py 中的路径配置
+# 根据实际情况修改 config.py 中的路径与门控参数
 python reconstruct_from_pickle.py
 ```
 
@@ -74,7 +75,7 @@ python reconstruct_from_pickle.py
 
 ### 2. 视频生成
 ```bash
-# 修改 make_video.py 中的路径配置
+# 根据实际情况修改 config.py 中的路径与可视化参数
 python make_video.py
 ```
 
@@ -83,17 +84,28 @@ python make_video.py
 
 ## 配置参数
 
-### 重建参数
-- `PCUTOFF = 0.35`：置信度阈值
-- `HEAD_TAIL_SAMPLE = 5`：头尾平均中心采样帧数
-- `MAX_GAP_FRAMES = 60`：最大时间间隔
-- `ANCHOR_MIN_HITS = 1`：锚点最少RFID命中数
+`config.py` 集中定义了默认路径与门控参数，包含以下常见设置：
+
+### 路径相关
+- `PICKLE_IN` / `PICKLE_OUT`：输入和输出的 tracklet pickle 文件
+- `VIDEO_PATH` / `OUTPUT_VIDEO`：原始视频与生成视频路径
+- `CENTERS_TXT`：读卡器中心文件
+- `ROI_FILE`：ROI 区域定义文件
+
+### 门控与重建参数
+- `FPS`：相机帧率
+- `PX_PER_CM`：像素与厘米换算
+- `V_GATE_CMS`：速度门限
+- `PCUTOFF`：置信度阈值
+- `HEAD_TAIL_SAMPLE`：头尾平均中心采样帧数
+- `MAX_GAP_FRAMES`：最大时间间隔
+- `ANCHOR_MIN_HITS`：锚点最少 RFID 命中数
 
 ### 可视化参数
-- `TRAIL_LEN = 15`：tracklet轨迹长度
-- `CHAIN_TRAIL_LEN = 40`：身份链轨迹长度
-- `TAG_HOLD_FRAMES = 3`：RFID标签显示持续帧数
-- `MAX_FRAMES = None`：最大输出帧数（None=全部）
+- `TRAIL_LEN`：tracklet 轨迹长度
+- `CHAIN_TRAIL_LEN`：身份链轨迹长度
+- `TAG_HOLD_FRAMES`：RFID 标签显示持续帧数
+- `MAX_FRAMES`：最大输出帧数（`None` 表示全部）
 
 ## 数据格式
 
@@ -120,9 +132,9 @@ python make_video.py
 ## 重构改进
 
 相比原版本的主要改进：
-1. **简化结构**：删除了config.py，配置直接硬编码在各脚本中
-2. **统一工具函数**：所有共用函数集中在utils.py中
-3. **删除冗余**：移除了不必要的复杂导入逻辑和`__init__.py`
+1. **集中配置**：新增 `config.py`，所有路径与门控参数统一管理
+2. **统一工具函数**：所有共用函数集中在 `utils.py` 中
+3. **删除冗余**：移除了不必要的复杂导入逻辑和 `__init__.py`
 4. **清晰职责**：每个脚本专注单一功能
 5. **改进文档**：添加详细的函数和参数说明
 
@@ -136,6 +148,6 @@ python make_video.py
 
 ## 注意事项
 
-- 使用前需要根据实际数据路径修改各脚本中的路径配置
-- 确保输入的pickle文件包含正确的DLC tracklet数据结构
-- ROI文件格式目前只支持polygon类型的JSON格式
+- 使用前需要根据实际数据路径修改 `config.py`
+- 确保输入的 pickle 文件包含正确的 DLC tracklet 数据结构
+- ROI 文件格式目前只支持 polygon 类型的 JSON 格式

--- a/deeplabcut/rfid_tracking/config.py
+++ b/deeplabcut/rfid_tracking/config.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+# Base directory for RFID tracking scripts
+BASE_DIR = Path(__file__).resolve().parent
+
+# ================== 默认路径 ==================
+# 路径可根据实际项目调整
+PICKLE_IN = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/demoDLC_HrnetW32_MiceTrackerFor20Dec8shuffle3_detector_best-250_snapshot_best-190_el.pickle"
+PICKLE_OUT = None            # None 表示覆盖输入
+OUT_SUBDIR = "CAP15"          # 输出子目录; 设为 None 则直接写入同级目录
+
+VIDEO_PATH = "/ssd01/user_acc_data/oppa/deeplabcut/videos/test/demo.mp4"
+PICKLE_PATH = PICKLE_IN      # make_video 默认使用同一 pickle
+OUTPUT_VIDEO = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/CAP15/demo_tracked.mp4"
+
+CENTERS_TXT = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/readers_centers.txt"
+ROI_FILE = "/ssd01/user_acc_data/oppa/analysis/rfid_dlc_tracking/version2_tracking/roi_definitions.json"
+
+# convert_detection2tracklets 默认参数文件
+CONVERT_DEFAULTS = BASE_DIR / "convert_detection2tracklets_config.yaml"
+
+# ================== 门控与重建参数 ==================
+FPS = 30.0                # 帧率 (frames/second)
+PX_PER_CM = 14.0          # 像素与厘米换算
+V_GATE_CMS = 80.0         # 最大速度门限 (cm/s)
+
+PCUTOFF = 0.35
+HEAD_TAIL_SAMPLE = 5
+MAX_GAP_FRAMES = 60
+ANCHOR_MIN_HITS = 1
+
+EPS_GAP = 0.5
+DELTA_PX_CAP = 15.0
+DELTA_PROP = 0.10
+
+STOP_NEAR_ANCHOR = True
+RESET_PREVIOUS = True
+LOG_RUN_METADATA = True
+
+# ================== 可视化参数 ==================
+TRAIL_LEN = 15
+TAG_HOLD_FRAMES = 3
+
+SHOW_CHAIN = True
+CHAIN_FALLBACK_ID = True
+CHAIN_TRAIL_LEN = 40
+CHAIN_LINE_THICK = 3
+CHAIN_POINT_R = 5
+
+DRAW_LEGEND = True
+LEGEND_COLS = 2
+LEGEND_POS = (20, 40)
+
+DRAW_READERS = True
+DRAW_ROIS = True
+
+MAX_FRAMES = None

--- a/deeplabcut/rfid_tracking/convert_detection2tracklets.py
+++ b/deeplabcut/rfid_tracking/convert_detection2tracklets.py
@@ -13,7 +13,12 @@ import click
 import deeplabcut as dlc
 from deeplabcut.utils import auxiliaryfunctions as aux
 
-DEFAULTS_PATH = Path(__file__).with_name("convert_detection2tracklets_config.yaml")
+try:  # 允许作为脚本或模块运行
+    from . import config
+except ImportError:  # pragma: no cover
+    import config
+
+DEFAULTS_PATH = config.CONVERT_DEFAULTS
 
 
 def collect_videos(input_path: str, videotype: Optional[str]):

--- a/deeplabcut/rfid_tracking/make_video.py
+++ b/deeplabcut/rfid_tracking/make_video.py
@@ -21,40 +21,37 @@ from .visualization import (
     load_rois, draw_rois
 )
 
+try:  # 允许作为脚本或模块运行
+    from . import config
+except ImportError:  # pragma: no cover
+    import config
+
 # ================== 配置参数 ==================
-# 文件路径
-VIDEO_PATH = "/ssd01/user_acc_data/oppa/deeplabcut/videos/test/demo.mp4"
-PICKLE_PATH = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/CAP15/demoDLC_HrnetW32_MiceTrackerFor20Dec8shuffle3_detector_best-250_snapshot_best-190_el.pickle"
-# 输出到指定文件夹
-OUTPUT_VIDEO = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/CAP15/demo_tracked.mp4"
+VIDEO_PATH = config.VIDEO_PATH
+PICKLE_PATH = config.PICKLE_PATH
+OUTPUT_VIDEO = config.OUTPUT_VIDEO
 
-# 读卡器可视化
-DRAW_READERS = True
-CENTERS_TXT = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/readers_centers.txt"
+DRAW_READERS = config.DRAW_READERS
+CENTERS_TXT = config.CENTERS_TXT
 
-# ROI可视化
-DRAW_ROIS = True
-ROI_FILE = "/ssd01/user_acc_data/oppa/analysis/rfid_dlc_tracking/version2_tracking/roi_definitions.json"
+DRAW_ROIS = config.DRAW_ROIS
+ROI_FILE = config.ROI_FILE
 
-# 轨迹参数
-PCUTOFF = 0.35                # 置信度阈值
-TRAIL_LEN = 15                # tracklet轨迹长度
-TAG_HOLD_FRAMES = 3           # RFID标签显示持续帧数
+PCUTOFF = config.PCUTOFF
+TRAIL_LEN = config.TRAIL_LEN
+TAG_HOLD_FRAMES = config.TAG_HOLD_FRAMES
 
-# 身份链可视化
-SHOW_CHAIN = True             # 是否显示重建的身份链
-CHAIN_FALLBACK_ID = True      # 是否使用chain_id作为回退
-CHAIN_TRAIL_LEN = 40          # 身份链轨迹长度
-CHAIN_LINE_THICK = 3          # 身份链线条粗细
-CHAIN_POINT_R = 5             # 身份链端点半径
+SHOW_CHAIN = config.SHOW_CHAIN
+CHAIN_FALLBACK_ID = config.CHAIN_FALLBACK_ID
+CHAIN_TRAIL_LEN = config.CHAIN_TRAIL_LEN
+CHAIN_LINE_THICK = config.CHAIN_LINE_THICK
+CHAIN_POINT_R = config.CHAIN_POINT_R
 
-# 图例设置
-DRAW_LEGEND = True            # 是否绘制图例
-LEGEND_COLS = 2               # 图例列数
-LEGEND_POS = (20, 40)         # 图例位置
+DRAW_LEGEND = config.DRAW_LEGEND
+LEGEND_COLS = config.LEGEND_COLS
+LEGEND_POS = config.LEGEND_POS
 
-# 输出限制
-MAX_FRAMES = None             # 最大输出帧数（None=全部）
+MAX_FRAMES = config.MAX_FRAMES
 
 # ================== 小工具 ==================
 def draw_label_with_bg(img, text, org, font_scale=0.6, thickness=2, fg=(255,255,255), bg=(0,0,0), alpha=0.4, padding=4):

--- a/deeplabcut/rfid_tracking/reconstruct_from_pickle.py
+++ b/deeplabcut/rfid_tracking/reconstruct_from_pickle.py
@@ -22,34 +22,33 @@ import pandas as pd
 from .io import load_tracklets_pickle, save_pickle_safely
 from .dlc_tools import frame_idx_from_key, find_mouse_center_index, body_center_from_arr
 
+try:  # 允许作为脚本或模块运行
+    from . import config
+except ImportError:  # pragma: no cover
+    import config
+
 # ================== 配置参数 ==================
-# 输入输出路径
-PICKLE_IN  = "/ssd01/user_acc_data/oppa/deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/demoDLC_HrnetW32_MiceTrackerFor20Dec8shuffle3_detector_best-250_snapshot_best-190_el.pickle"
-PICKLE_OUT = None                # None=覆盖输入；或给出新路径
-OUT_SUBDIR = "CAP15"             # 输出到输入pickle同目录下的子目录；设 None 则不用子目录
+PICKLE_IN = config.PICKLE_IN
+PICKLE_OUT = config.PICKLE_OUT
+OUT_SUBDIR = config.OUT_SUBDIR
 
-# 相机与门控
-FPS        = 30.0                # 帧/秒
-PX_PER_CM  = 14.0                # 像素/厘米（相机标定）
-V_GATE_CMS = 80.0                # cm/s
+FPS = config.FPS
+PX_PER_CM = config.PX_PER_CM
+V_GATE_CMS = config.V_GATE_CMS
 
-# 重建参数
-PCUTOFF            = 0.35
-HEAD_TAIL_SAMPLE   = 5
-MAX_GAP_FRAMES     = 60
-ANCHOR_MIN_HITS    = 1
+PCUTOFF = config.PCUTOFF
+HEAD_TAIL_SAMPLE = config.HEAD_TAIL_SAMPLE
+MAX_GAP_FRAMES = config.MAX_GAP_FRAMES
+ANCHOR_MIN_HITS = config.ANCHOR_MIN_HITS
 
-# 同步推进裁决参数（只作用于冲突裁决，不改变门控本质）
-EPS_GAP       = 0.5              # cost = d + EPS_GAP * gap（设 0 可关闭）
-DELTA_PX_CAP  = 15.0             # 歧义冻结像素上限（代价差可接受阈值）
-DELTA_PROP    = 0.10             # 歧义冻结相对门槛（门控上限的 10%）
+EPS_GAP = config.EPS_GAP
+DELTA_PX_CAP = config.DELTA_PX_CAP
+DELTA_PROP = config.DELTA_PROP
 
-# 邻近锚点“堤坝止水”
-STOP_NEAR_ANCHOR = True
+STOP_NEAR_ANCHOR = config.STOP_NEAR_ANCHOR
 
-# 可重复运行支持
-RESET_PREVIOUS   = True          # 运行前清理旧的 chain_* 字段
-LOG_RUN_METADATA = True          # 记录本次运行参数（安全写法）
+RESET_PREVIOUS = config.RESET_PREVIOUS
+LOG_RUN_METADATA = config.LOG_RUN_METADATA
 
 
 # ================== 工具函数 ==================


### PR DESCRIPTION
## Summary
- add shared `config.py` for RFID tracking scripts
- import unified config in `reconstruct_from_pickle`, `make_video` and `convert_detection2tracklets`
- document configuration options in `rfid_tracking/README.md`

## Testing
- `python -m py_compile deeplabcut/rfid_tracking/config.py deeplabcut/rfid_tracking/reconstruct_from_pickle.py deeplabcut/rfid_tracking/make_video.py deeplabcut/rfid_tracking/convert_detection2tracklets.py`
- `pytest deeplabcut/rfid_tracking -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad84c0ef58832298c93de21397d0ee