### PR TITLE
feat: make RFID matching configurable

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -86,7 +86,23 @@ python convert_detection2tracklets.py --config-path <项目config.yaml> --video-
 - `--destfolder`：输出目录（默认跟随视频路径）
 - `--videotype`：目录模式下的视频后缀
 
-### 1. 轨迹重建
+### 1. RFID 与 tracklet 匹配
+```bash
+# 在 config.py 中设置 MRT_* 路径或提供 YAML 覆盖
+python match_rfid_to_tracklets.py                # 使用 config.py 中的默认值
+python match_rfid_to_tracklets.py --config my_mrt.yaml  # 读取外部 YAML
+```
+
+示例 YAML (`my_mrt.yaml`):
+```yaml
+MRT_PICKLE_PATH: /path/to/tracklets.pickle
+MRT_RFID_CSV: /path/to/rfid.csv
+MRT_CENTERS_TXT: /path/to/readers_centers.txt
+MRT_TS_CSV: /path/to/timestamps.csv
+MRT_OUT_DIR: ./rfid_match_outputs
+```
+
+### 2. 轨迹重建
 ```bash
 # 根据实际情况修改 config.py 中的路径与门控参数
 python reconstruct_from_pickle.py
@@ -96,7 +112,7 @@ python reconstruct_from_pickle.py
 - 更新后的pickle文件（包含chain_tag和chain_id）
 - `chain_segments.csv`：链段详细信息
 
-### 2. 视频生成
+### 3. 视频生成
 ```bash
 # 根据实际情况修改 config.py 中的路径与可视化参数
 python make_video.py
@@ -129,6 +145,13 @@ python make_video.py
 - `CHAIN_TRAIL_LEN`：身份链轨迹长度
 - `TAG_HOLD_FRAMES`：RFID 标签显示持续帧数
 - `MAX_FRAMES`：最大输出帧数（`None` 表示全部）
+
+### match_rfid_to_tracklets 参数
+- `MRT_PICKLE_PATH` / `MRT_RFID_CSV` / `MRT_CENTERS_TXT` / `MRT_TS_CSV` / `MRT_OUT_DIR`
+- `MRT_HIT_RADIUS_PX`、`MRT_AMBIG_MARGIN_PX`、`MRT_TAG_CONFIDENCE_THRESHOLD` 等匹配门槛
+
+这些参数可直接在 `config.py` 中修改，或写入 YAML 后通过
+`python match_rfid_to_tracklets.py --config my_mrt.yaml` 加载。
 
 ## 数据格式
 

--- a/deeplabcut/rfid_tracking/config.py
+++ b/deeplabcut/rfid_tracking/config.py
@@ -55,3 +55,53 @@ DRAW_READERS = True
 DRAW_ROIS = True
 
 MAX_FRAMES = None
+
+# ================== match_rfid_to_tracklets 默认参数 ==================
+# 路径可在此修改，或通过 load_mrt_config 从 YAML 覆盖
+MRT_PICKLE_PATH = PICKLE_IN
+MRT_RFID_CSV = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/rfid_data_20250813_055827.csv"
+MRT_CENTERS_TXT = CENTERS_TXT
+MRT_TS_CSV = "/ssd01/user_acc_data/oppa/analysis/data/jc0813/record_20250813_053913_timestamps.csv"
+MRT_OUT_DIR = None  # None -> 与 pickle 同目录创建 rfid_match_outputs/
+
+MRT_N_ROWS = 12
+MRT_N_COLS = 12
+MRT_ID_BASE = 0
+MRT_Y_TOP_TO_BOTTOM = True
+
+MRT_PCUTOFF = 0.35
+MRT_RFID_FRAME_RANGE = 10
+MRT_COIL_DIAMETER_PX = 170.0
+MRT_HIT_MARGIN = 1.00
+MRT_HIT_RADIUS_PX = (MRT_COIL_DIAMETER_PX / 2.0) * MRT_HIT_MARGIN
+
+MRT_UNIQUE_NEIGHBOR_ONLY = True
+MRT_AMBIG_MARGIN_PX = 75.0
+
+MRT_LOW_FREQ_TAG_MIN_COUNT = 2
+MRT_MIN_VALID_FRAMES_PER_TK = 1
+
+MRT_TAG_CONFIDENCE_THRESHOLD = 0.70
+MRT_TAG_MIN_READS = 20
+MRT_TAG_DOMINANT_RATIO = 3.0
+MRT_LOW_READS_HIGH_PURITY_ASSIGN = True
+MRT_LOW_READS_PURITY_THRESHOLD = 0.90
+
+MRT_USE_FRAME_STABILITY_CHECK = False
+MRT_BURST_GAP_FRAMES = 150
+MRT_MIN_BURSTS_IF_LOWHITS = 2
+MRT_LOWHITS_THRESHOLD = 200
+
+
+def load_mrt_config(yaml_path: str) -> None:
+    """Override MRT_* defaults from a YAML file."""
+    import yaml
+
+    with open(yaml_path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+
+    for key, value in data.items():
+        key = key if key.startswith("MRT_") else f"MRT_{key}".upper()
+        if key in globals():
+            globals()[key] = value
+


### PR DESCRIPTION
## Summary
- add match_rfid_to_tracklets defaults to `config.py` and YAML loader
- refactor matcher to read settings from config and allow `--config` overrides
- document new MRT_* configuration and YAML usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'deeplabcut')*
- `python -m deeplabcut.rfid_tracking.match_rfid_to_tracklets --help` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ada8db98288322b5753c5a6bddb72b