### PR TITLE
Refactor RFID tracking utilities to accept parameters

### DIFF
--- a/deeplabcut/rfid_tracking/make_video.py
+++ b/deeplabcut/rfid_tracking/make_video.py
@@ -364,17 +364,28 @@ def draw_chain_legend(frame, chain_trail, pos=(20, 40), cols=2):
 
 
 # ================== 主函数 ==================
-def main():
+def main(
+    *,
+    video_path: str | None = None,
+    pickle_path: str | None = None,
+    centers_txt: str | None = None,
+    output_video: str | None = None,
+) -> None:
     """主函数"""
+    video_path = video_path or VIDEO_PATH
+    pickle_path = pickle_path or PICKLE_PATH
+    centers_txt = centers_txt or CENTERS_TXT
+    output_video = output_video or OUTPUT_VIDEO
+
     # 检查文件是否存在
-    for pth, msg in [(VIDEO_PATH, "视频"), (PICKLE_PATH, "pickle")]:
+    for pth, msg in [(video_path, "视频"), (pickle_path, "pickle")]:
         if not Path(pth).exists():
             print(f"错误：{msg}文件不存在: {pth}")
             return
 
     # 加载数据
     print("正在加载tracklet数据...")
-    dd = load_tracklets_pickle(PICKLE_PATH)
+    dd = load_tracklets_pickle(pickle_path)
 
     print("构建每帧数据结构...")
     (
@@ -392,8 +403,8 @@ def main():
 
     # 加载读卡器位置（可选）
     reader_positions = None
-    if DRAW_READERS and Path(CENTERS_TXT).exists():
-        centers, meta = parse_centers(CENTERS_TXT)
+    if DRAW_READERS and Path(centers_txt).exists():
+        centers, meta = parse_centers(centers_txt)
         reader_positions = centers_to_reader_positions_column_major(centers, meta)
         print(f"读取到 {len(reader_positions)} 个读卡器位置")
 
@@ -407,7 +418,7 @@ def main():
         print(f"加载了 {len(rois)} 个ROI区域")
 
     # 打开视频
-    cap = cv2.VideoCapture(VIDEO_PATH)
+    cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         print("错误：无法打开视频文件")
         return
@@ -420,7 +431,7 @@ def main():
 
     # 设置输出视频
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-    out = cv2.VideoWriter(OUTPUT_VIDEO, fourcc, fps if fps > 0 else 25.0, (W, H))
+    out = cv2.VideoWriter(output_video, fourcc, fps if fps > 0 else 25.0, (W, H))
 
     max_frames = T if MAX_FRAMES is None else min(T, MAX_FRAMES)
     print(f"视频信息: {W}x{H}, {fps:.2f}fps, 共 {T} 帧；将输出 {max_frames} 帧")
@@ -477,7 +488,7 @@ def main():
     cap.release()
     out.release()
     cv2.destroyAllWindows()
-    print(f"[OK] 完成！输出视频: {OUTPUT_VIDEO}")
+    print(f"[OK] 完成！输出视频: {output_video}")
 
 
 if __name__ == "__main__":

--- a/deeplabcut/rfid_tracking/pipeline.py
+++ b/deeplabcut/rfid_tracking/pipeline.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
-from . import make_video, match_rfid_to_tracklets, reconstruct_from_pickle
+from .make_video import main as make_video
+from .match_rfid_to_tracklets import main as match_rfid_to_tracklets
+from .reconstruct_from_pickle import main as reconstruct_from_pickle
 
 
 def run_pipeline(
@@ -88,31 +90,32 @@ def run_pipeline(
     track_pickle = dest / f"{video_path.stem}{dlc_scorer}_{method_suffix}.pickle"
 
     # 3) match RFID events to tracklets
-    mrf = match_rfid_to_tracklets
-    mrf.PICKLE_PATH = str(track_pickle)
-    mrf.RFID_CSV = rfid_csv
-    mrf.CENTERS_TXT = centers_txt
-    mrf.TS_CSV = ts_csv
-    mrf.OUT_DIR = None
-    mrf.main()
+    match_rfid_to_tracklets(
+        pickle_path=str(track_pickle),
+        rfid_csv=rfid_csv,
+        centers_txt=centers_txt,
+        ts_csv=ts_csv,
+        out_dir=None,
+    )
 
     # 4) reconstruct identity chains
-    rec = reconstruct_from_pickle
-    rec.PICKLE_IN = str(track_pickle)
-    rec.PICKLE_OUT = None
-    rec.OUT_SUBDIR = None
-    rec.main()
+    reconstruct_from_pickle(
+        pickle_in=str(track_pickle),
+        pickle_out=None,
+        out_subdir=None,
+    )
 
     # 5) generate visualization video
-    mkv = make_video
-    mkv.VIDEO_PATH = str(video_path)
-    mkv.PICKLE_PATH = str(track_pickle)
-    mkv.CENTERS_TXT = centers_txt
-    mkv.OUTPUT_VIDEO = (
-        str(Path(output_video))
+    out_vid = (
+        Path(output_video)
         if output_video
-        else str(dest / f"{video_path.stem}_rfid_tracklets_overlay.mp4")
+        else dest / f"{video_path.stem}_rfid_tracklets_overlay.mp4"
     )
-    mkv.main()
+    make_video(
+        video_path=str(video_path),
+        pickle_path=str(track_pickle),
+        centers_txt=centers_txt,
+        output_video=str(out_vid),
+    )
 
-    return mkv.OUTPUT_VIDEO
+    return str(out_vid)

--- a/deeplabcut/rfid_tracking/reconstruct_from_pickle.py
+++ b/deeplabcut/rfid_tracking/reconstruct_from_pickle.py
@@ -405,14 +405,19 @@ def reconstruct_by_timespeed_gate(dd: Dict):
 
 
 # ================== 运行入口 ==================
-def main():
-    p_in = Path(PICKLE_IN)
-    if OUT_SUBDIR:
-        out_dir = p_in.parent / OUT_SUBDIR
+def main(
+    *,
+    pickle_in: str | None = None,
+    pickle_out: str | None = None,
+    out_subdir: str | None = None,
+) -> None:
+    p_in = Path(pickle_in or PICKLE_IN)
+    out_subdir = out_subdir if out_subdir is not None else OUT_SUBDIR
+    p_out = p_in if pickle_out is None else Path(pickle_out)
+    if out_subdir:
+        out_dir = p_in.parent / out_subdir
         out_dir.mkdir(parents=True, exist_ok=True)
         p_out = out_dir / p_in.name  # 保留原文件名
-    else:
-        p_out = p_in if PICKLE_OUT is None else Path(PICKLE_OUT)
 
     if not p_in.exists():
         print(f"错误：输入文件不存在: {p_in}")


### PR DESCRIPTION
## Summary
- Accept explicit file and directory arguments in `match_rfid_to_tracklets`, `reconstruct_from_pickle`, and `make_video`
- Update RFID `run_pipeline` to call these utilities with the new parameters
- Add CLI options for `match_rfid_to_tracklets` to expose the parameters

## Testing
- `pytest deeplabcut/rfid_tracking -q`

------
https://chatgpt.com/codex/tasks/task_e_68adb03bce1883229540b71e2d51aa41