### PR TITLE
Validate track_method in RFID pipeline

### DIFF
--- a/deeplabcut/rfid_tracking/pipeline.py
+++ b/deeplabcut/rfid_tracking/pipeline.py
@@ -72,6 +72,13 @@ def run_pipeline(
     )
 
     # 2) convert detections to tracklets
+    valid_methods = {"ellipse", "skeleton", "box"}
+    if track_method not in valid_methods:
+        raise ValueError(
+            f"Unsupported track_method '{track_method}'. Supported methods are: "
+            f"{', '.join(sorted(valid_methods))}."
+        )
+
     convert_detections2tracklets(
         config=config_path,
         videos=[str(video_path)],


### PR DESCRIPTION
## Summary
- ensure `run_pipeline` only accepts ellipse, skeleton, or box tracking methods
- raise a clear `ValueError` when an unsupported `track_method` is supplied

## Testing
- `pre-commit run --files deeplabcut/rfid_tracking/pipeline.py`
- `PYTHONPATH=. pytest tests/test_trackingutils.py::test_sort_ellipse -q`

------
https://chatgpt.com/codex/tasks/task_e_68adb23aab408322a3298129493de03f