### PR TITLE
Use provided pickle path for RFID matching

### DIFF
--- a/deeplabcut/rfid_tracking/match_rfid_to_tracklets.py
+++ b/deeplabcut/rfid_tracking/match_rfid_to_tracklets.py
@@ -589,7 +589,7 @@ def main(
     }
 
     # 9) 写回 pickle + Tag 分配（一次完成）
-    orig_path = Path(PICKLE_PATH)
+    orig_path = Path(pickle_path)
     backup_path = orig_path.with_name(orig_path.name + ".bak")
     tmp_path = orig_path.with_name(orig_path.name + ".tmp")
 


### PR DESCRIPTION
## Summary
- derive pickle writeback paths from the function argument instead of the global constant

## Testing
- `python -m deeplabcut.rfid_tracking.match_rfid_to_tracklets --config tmp_rfid/config.yaml --pickle tmp_rfid/tracklets.pkl --rfid_csv tmp_rfid/rfid.csv --centers tmp_rfid/centers.txt --ts tmp_rfid/timestamps.csv --out_dir tmp_rfid/out`
- `python - <<'PY'\nimport pickle, pprint\nfrom pathlib import Path\np=Path('tmp_rfid/tracklets.pkl')\nwith open(p,'rb') as f:\n    data=pickle.load(f)\nprint(data.keys())\nprint('tracklet tk1 keys:', data['tk1'].keys())\nprint('rfid_frames:', data['tk1'].get('rfid_frames'))\nprint('tag:', data['tk1'].get('tag'))\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68aeca7741a48322856f29fd5e08eedd