### PR TITLE
Fix path handling for reconstructed RFID tracklets

### DIFF
--- a/deeplabcut/rfid_tracking/pipeline.py
+++ b/deeplabcut/rfid_tracking/pipeline.py
@@ -6,7 +6,10 @@ import logging
 
 from .make_video import main as make_video
 from .match_rfid_to_tracklets import main as match_rfid_to_tracklets
-from .reconstruct_from_pickle import main as reconstruct_from_pickle
+from .reconstruct_from_pickle import (
+    main as reconstruct_from_pickle,
+    OUT_SUBDIR as RECON_OUT_SUBDIR,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -150,8 +153,10 @@ def run_pipeline(
     reconstruct_from_pickle(
         pickle_in=str(track_pickle),
         pickle_out=None,
-        out_subdir=None,
+        out_subdir=RECON_OUT_SUBDIR,
     )
+    if RECON_OUT_SUBDIR:
+        track_pickle = track_pickle.parent / RECON_OUT_SUBDIR / track_pickle.name
     logger.info("Finished reconstructing identity chains for %s", track_pickle)
 
     # 5) generate visualization video

--- a/deeplabcut/rfid_tracking/reconstruct_from_pickle.py
+++ b/deeplabcut/rfid_tracking/reconstruct_from_pickle.py
@@ -412,7 +412,9 @@ def main(
     out_subdir: str | None = None,
 ) -> None:
     p_in = Path(pickle_in or PICKLE_IN)
-    out_subdir = out_subdir if out_subdir is not None else OUT_SUBDIR
+    # Use the configured subdirectory only when explicitly requested;
+    # passing ``None`` keeps outputs alongside the input pickle.
+    out_subdir = OUT_SUBDIR if out_subdir is not None else None
     p_out = p_in if pickle_out is None else Path(pickle_out)
     if out_subdir:
         out_dir = p_in.parent / out_subdir


### PR DESCRIPTION
## Summary
- Respect `out_subdir=None` in `reconstruct_from_pickle.main`, keeping outputs alongside the input pickle
- Pass `OUT_SUBDIR` through `pipeline.run_pipeline` and update `track_pickle` when a subdirectory is used

## Testing
- `python - <<'PY'
from deeplabcut.rfid_tracking.reconstruct_from_pickle import main

main(pickle_in='dummy_tracklets.pickle', pickle_out=None, out_subdir=None)
PY`
- `pytest -q deeplabcut/rfid_tracking`
- `python - <<'PY'
from deeplabcut.rfid_tracking.pipeline import run_pipeline
try:
    run_pipeline('nonexistent_config.yaml','nonexistent_video.mp4','rfid.csv','centers.txt','ts.csv')
except Exception as e:
    print('run_pipeline failed:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aecbb02c208322b18d00f68564e1ba