### PR TITLE
Enable YAML configuration overrides for RFID pipeline

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -153,6 +153,48 @@ python make_video.py
 这些参数可直接在 `config.py` 中修改，或写入 YAML 后通过
 `python match_rfid_to_tracklets.py --config my_mrt.yaml` 加载。
 
+### YAML 配置覆盖 (`load_config`)
+
+通过新提供的 `load_config` 函数，可以在单独的 YAML 文件中定义配置，
+运行流程前加载该文件即可覆盖 `config.py` 中的任何变量。YAML 中的键
+需与变量名一致。
+
+#### 路径相关
+- `PICKLE_IN` / `PICKLE_OUT`
+- `VIDEO_PATH` / `OUTPUT_VIDEO`
+- `CENTERS_TXT` / `ROI_FILE`
+
+#### `MRT_*` 参数
+- `MRT_RFID_CSV` / `MRT_TS_CSV` / `MRT_CENTERS_TXT` / `MRT_PICKLE_PATH`
+- 以及所有其他 `MRT_` 前缀的匹配与门控参数
+
+#### 可视化开关
+- `SHOW_CHAIN` / `CHAIN_FALLBACK_ID`
+- `DRAW_READERS` / `DRAW_ROIS`
+- `MAX_FRAMES` 等
+
+示例 YAML:
+
+```yaml
+# 路径
+PICKLE_IN: /path/to/tracklets.pickle
+CENTERS_TXT: /path/to/readers_centers.txt
+
+# MRT 参数
+MRT_RFID_CSV: /path/to/rfid.csv
+
+# 可视化
+SHOW_CHAIN: true
+DRAW_READERS: false
+```
+
+在命令行运行全流程时，可使用 `--config_override` 传入该 YAML：
+
+```bash
+python run_pipeline.py config.yaml video.mp4 rfid.csv centers.txt ts.csv \
+    --config_override my_config.yaml
+```
+
 ## 数据格式
 
 ### ROI定义文件 (JSON)

--- a/deeplabcut/rfid_tracking/__init__.py
+++ b/deeplabcut/rfid_tracking/__init__.py
@@ -2,10 +2,12 @@ from .match_rfid_to_tracklets import main as match_rfid_to_tracklets
 from .reconstruct_from_pickle import main as reconstruct_from_pickle
 from .make_video import main as make_video
 from .pipeline import run_pipeline
+from .config import load_config
 
 __all__ = [
     "match_rfid_to_tracklets",
     "reconstruct_from_pickle",
     "make_video",
     "run_pipeline",
+    "load_config",
 ]

--- a/deeplabcut/rfid_tracking/config.py
+++ b/deeplabcut/rfid_tracking/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 # Base directory for RFID tracking scripts
@@ -93,6 +95,34 @@ MRT_MIN_BURSTS_IF_LOWHITS = 2
 MRT_LOWHITS_THRESHOLD = 200
 
 
+def _apply_overrides(data: dict) -> None:
+    """Update module globals with ``data`` items if keys exist."""
+    for key, value in data.items():
+        key = key.upper()
+        if key in globals():
+            globals()[key] = value
+
+
+def load_config(path: str | Path | None) -> None:
+    """Override default settings from a YAML file.
+
+    Parameters
+    ----------
+    path : str | Path | None
+        YAML file containing overrides. If ``None`` the function returns
+        immediately.
+    """
+    if path is None:
+        return
+
+    import yaml
+
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+
+    _apply_overrides(data)
+
+
 def load_mrt_config(yaml_path: str) -> None:
     """Override MRT_* defaults from a YAML file."""
     import yaml
@@ -100,8 +130,10 @@ def load_mrt_config(yaml_path: str) -> None:
     with open(yaml_path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
 
-    for key, value in data.items():
-        key = key if key.startswith("MRT_") else f"MRT_{key}".upper()
-        if key in globals():
-            globals()[key] = value
+    overrides = {
+        (key if key.startswith("MRT_") else f"MRT_{key}".upper()): value
+        for key, value in data.items()
+    }
+
+    _apply_overrides(overrides)
 

--- a/deeplabcut/rfid_tracking/pipeline.py
+++ b/deeplabcut/rfid_tracking/pipeline.py
@@ -26,6 +26,7 @@ def run_pipeline(
     destfolder: Optional[str] = None,
     trainingsetindex: int = 0,
     output_video: Optional[str] = None,
+    config_override: str | Path | None = None,
 ) -> str:
     """Run the full video + RFID analysis pipeline.
 
@@ -55,6 +56,9 @@ def run_pipeline(
     output_video : str, optional
         Path of the final visualization video. If ``None``, a file named
         ``<video>_rfid_tracklets_overlay.mp4`` will be created in ``destfolder``.
+    config_override : str | Path, optional
+        YAML file to override values in :mod:`rfid_tracking.config` before
+        running the pipeline.
 
     Notes
     -----
@@ -70,6 +74,8 @@ def run_pipeline(
     from deeplabcut import analyze_videos, convert_detections2tracklets
     from deeplabcut.utils import auxiliaryfunctions as aux
     from deeplabcut.utils.auxiliaryfunctions import get_scorer_name
+
+    cfg.load_config(config_override)
 
     config_path = Path(config_path)
     if not config_path.exists():

--- a/deeplabcut/rfid_tracking/run_pipeline.py
+++ b/deeplabcut/rfid_tracking/run_pipeline.py
@@ -25,6 +25,11 @@ def main() -> None:
     parser.add_argument("--destfolder", default=None, help="Output directory for intermediates")
     parser.add_argument("--trainingsetindex", type=int, default=0, help="DLC training set index")
     parser.add_argument("--output_video", default=None, help="Path for final overlay video")
+    parser.add_argument(
+        "--config_override",
+        default=None,
+        help="YAML file to override rfid_tracking.config settings",
+    )
     args = parser.parse_args()
     run_pipeline(**vars(args))
 


### PR DESCRIPTION
## Summary
- Add `load_config` to apply YAML overrides to `rfid_tracking.config` and refactor `load_mrt_config`
- Expose `load_config` and support passing a `config_override` to `run_pipeline`
- Document YAML-based configuration in RFID tracking README

## Testing
- `pytest -q deeplabcut/rfid_tracking`

------
https://chatgpt.com/codex/tasks/task_e_68afe550add88322a167c1542678f7b5