### PR TITLE
Add helper scripts for RFID tracking pipeline

### DIFF
--- a/deeplabcut/rfid_tracking/scripts/run_full_pipeline.py
+++ b/deeplabcut/rfid_tracking/scripts/run_full_pipeline.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Run the entire RFID tracking pipeline with preset paths."""
+
+from deeplabcut.rfid_tracking.pipeline import run_pipeline
+
+# Update these paths to match your environment
+CONFIG_PATH = "/data/myproject/config.yaml"
+VIDEO_PATH = "/data/myproject/video.mp4"
+RFID_CSV = "/data/myproject/rfid_events.csv"
+CENTERS_TXT = "/data/myproject/readers_centers.txt"
+TS_CSV = "/data/myproject/timestamps.csv"
+
+
+def main() -> None:
+    """Execute :func:`run_pipeline` with default arguments."""
+    run_pipeline(
+        config_path=CONFIG_PATH,
+        video_path=VIDEO_PATH,
+        rfid_csv=RFID_CSV,
+        centers_txt=CENTERS_TXT,
+        ts_csv=TS_CSV,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/deeplabcut/rfid_tracking/scripts/run_make_video.py
+++ b/deeplabcut/rfid_tracking/scripts/run_make_video.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Create a visualization video with preset file paths."""
+
+from deeplabcut.rfid_tracking.make_video import main as make_video
+
+VIDEO_PATH = "/data/myproject/video.mp4"
+PICKLE_PATH = "/data/myproject/reconstructed_tracklets.pickle"
+CENTERS_TXT = "/data/myproject/readers_centers.txt"
+OUTPUT_VIDEO = "/data/myproject/output_overlay.mp4"
+
+
+def main() -> None:
+    """Invoke :func:`make_video` using default arguments."""
+    make_video(
+        video_path=VIDEO_PATH,
+        pickle_path=PICKLE_PATH,
+        centers_txt=CENTERS_TXT,
+        output_video=OUTPUT_VIDEO,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/deeplabcut/rfid_tracking/scripts/run_match_rfid.py
+++ b/deeplabcut/rfid_tracking/scripts/run_match_rfid.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Match RFID readings to tracklets using preset file locations."""
+
+from deeplabcut.rfid_tracking.match_rfid_to_tracklets import main as match_rfid
+
+# Default paths used in our local setup
+PICKLE_PATH = "/data/myproject/tracklets.pickle"
+RFID_CSV = "/data/myproject/rfid_events.csv"
+CENTERS_TXT = "/data/myproject/readers_centers.txt"
+TS_CSV = "/data/myproject/timestamps.csv"
+OUT_DIR = "/data/myproject/rfid_match_outputs"
+
+
+def main() -> None:
+    """Execute :func:`match_rfid` with the predefined parameters."""
+    match_rfid(
+        pickle_path=PICKLE_PATH,
+        rfid_csv=RFID_CSV,
+        centers_txt=CENTERS_TXT,
+        ts_csv=TS_CSV,
+        out_dir=OUT_DIR,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/deeplabcut/rfid_tracking/scripts/run_reconstruct.py
+++ b/deeplabcut/rfid_tracking/scripts/run_reconstruct.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Reconstruct trajectories from a pickle using preferred defaults."""
+
+from deeplabcut.rfid_tracking.reconstruct_from_pickle import main as reconstruct
+
+PICKLE_IN = "/data/myproject/tracklets_with_rfid.pickle"
+PICKLE_OUT = "/data/myproject/reconstructed_tracklets.pickle"
+
+
+def main() -> None:
+    """Invoke :func:`reconstruct` with predefined paths."""
+    reconstruct(pickle_in=PICKLE_IN, pickle_out=PICKLE_OUT)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add dedicated scripts for running the full RFID pipeline, RFID/tracklet matching, reconstruction and visualization

## Testing
- `pytest deeplabcut/rfid_tracking -q`
- `pytest tests/test_auxiliaryfunctions.py::test_get_snapshots_from_folder -q` *(fails: ModuleNotFoundError: No module named 'deeplabcut')*

------
https://chatgpt.com/codex/tasks/task_e_68aff73191d08322a47e18461dd8f7b7