### PR TITLE
Add configurable destfolder for RFID pipeline

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -69,9 +69,12 @@ run_rfid_pipeline(
     rfid_csv="path/to/rfid.csv",
     centers_txt="path/to/readers_centers.txt",
     ts_csv="path/to/timestamps.csv",
-    destfolder="path/to/output"  # 可选
+    destfolder="path/to/output"  # 可选；若省略则使用 ``config.DESTFOLDER``
 )
 ```
+
+如果在 `config.py` 中设置了 ``DESTFOLDER``，命令行运行 `run_pipeline.py`
+时可通过 `--destfolder` 参数覆盖该默认目录。
 
 该函数依次调用：
 
@@ -150,6 +153,7 @@ python scripts/run_make_video.py       # 生成可视化视频
 - `VIDEO_PATH` / `OUTPUT_VIDEO`：原始视频与生成视频路径
 - `CENTERS_TXT`：读卡器中心文件
 - `ROI_FILE`：ROI 区域定义文件
+- `DESTFOLDER`：中间结果输出目录（命令行参数会覆盖）
 
 ### 门控与重建参数
 - `FPS`：相机帧率
@@ -183,6 +187,7 @@ python scripts/run_make_video.py       # 生成可视化视频
 - `PICKLE_IN` / `PICKLE_OUT`
 - `VIDEO_PATH` / `OUTPUT_VIDEO`
 - `CENTERS_TXT` / `ROI_FILE`
+- `DESTFOLDER`
 
 #### `MRT_*` 参数
 - `MRT_RFID_CSV` / `MRT_TS_CSV` / `MRT_CENTERS_TXT` / `MRT_PICKLE_PATH`
@@ -199,6 +204,7 @@ python scripts/run_make_video.py       # 生成可视化视频
 # 路径
 PICKLE_IN: /path/to/tracklets.pickle
 CENTERS_TXT: /path/to/readers_centers.txt
+DESTFOLDER: ./outputs
 
 # MRT 参数
 MRT_RFID_CSV: /path/to/rfid.csv
@@ -208,10 +214,12 @@ SHOW_CHAIN: true
 DRAW_READERS: false
 ```
 
-在命令行运行全流程时，可使用 `--config_override` 传入该 YAML：
+在命令行运行全流程时，可使用 `--destfolder` 覆盖 `config.DESTFOLDER`，
+并通过 `--config_override` 传入该 YAML：
 
 ```bash
 python run_pipeline.py config.yaml video.mp4 rfid.csv centers.txt ts.csv \
+    --destfolder ./outputs \
     --config_override my_config.yaml
 ```
 

--- a/deeplabcut/rfid_tracking/config.py
+++ b/deeplabcut/rfid_tracking/config.py
@@ -11,6 +11,7 @@ BASE_DIR = Path(__file__).resolve().parent
 PICKLE_IN = None
 PICKLE_OUT = None  # None 表示覆盖输入
 OUT_SUBDIR = "CAP15"  # 输出子目录; 设为 None 则直接写入同级目录
+DESTFOLDER = None  # 中间结果输出目录; None 则使用视频所在目录
 
 VIDEO_PATH = PROJECT_ROOT / "deeplabcut/videos/test/demo.mp4"
 PICKLE_PATH = PICKLE_IN  # make_video 默认使用同一 pickle

--- a/deeplabcut/rfid_tracking/pipeline.py
+++ b/deeplabcut/rfid_tracking/pipeline.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Optional
-import logging
 
 from . import config as cfg
 from .make_video import main as make_video
 from .match_rfid_to_tracklets import main as match_rfid_to_tracklets
-from .reconstruct_from_pickle import (
-    main as reconstruct_from_pickle,
-    OUT_SUBDIR as RECON_OUT_SUBDIR,
-)
+from .reconstruct_from_pickle import main as reconstruct_from_pickle
+from .reconstruct_from_pickle import OUT_SUBDIR as RECON_OUT_SUBDIR
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +21,7 @@ def run_pipeline(
     ts_csv: Optional[str] = None,
     shuffle: int = 1,
     track_method: str = "ellipse",
-    destfolder: Optional[str] = None,
+    destfolder: Optional[str] = cfg.DESTFOLDER,
     trainingsetindex: int = 0,
     output_video: Optional[str] = None,
     config_override: str | Path | None = None,
@@ -50,7 +48,8 @@ def run_pipeline(
     track_method : str, optional
         Tracklet matching method ("ellipse", "skeleton", or "box").
     destfolder : str, optional
-        Directory for intermediate outputs. If ``None``, uses the video folder.
+        Directory for intermediate outputs. Defaults to ``cfg.DESTFOLDER``;
+        if ``None``, uses the video folder.
     trainingsetindex : int, optional
         Training set index used for the DLC model, by default ``0``.
     output_video : str, optional
@@ -89,7 +88,9 @@ def run_pipeline(
     if not rfid_csv.exists():
         raise FileNotFoundError(f"RFID CSV file not found: {rfid_csv}")
 
-    centers_txt = Path(centers_txt) if centers_txt is not None else Path(cfg.MRT_CENTERS_TXT)
+    centers_txt = (
+        Path(centers_txt) if centers_txt is not None else Path(cfg.MRT_CENTERS_TXT)
+    )
     if not centers_txt.exists():
         raise FileNotFoundError(f"Reader centers file not found: {centers_txt}")
 
@@ -151,9 +152,7 @@ def run_pipeline(
     track_pickle = dest / f"{video_path.stem}{dlc_scorer}_{method_suffix}.pickle"
 
     # 3) match RFID events to tracklets
-    logger.info(
-        "Matching RFID events from %s to tracklets: %s", rfid_csv, track_pickle
-    )
+    logger.info("Matching RFID events from %s to tracklets: %s", rfid_csv, track_pickle)
     match_rfid_to_tracklets(
         pickle_path=str(track_pickle),
         rfid_csv=str(rfid_csv),

--- a/deeplabcut/rfid_tracking/run_pipeline.py
+++ b/deeplabcut/rfid_tracking/run_pipeline.py
@@ -6,8 +6,10 @@ import argparse
 import logging
 
 try:  # allow running as script or module
+    from . import config as cfg
     from .pipeline import run_pipeline
 except ImportError:  # pragma: no cover
+    import config as cfg
     from pipeline import run_pipeline
 
 
@@ -21,10 +23,20 @@ def main() -> None:
     parser.add_argument("centers_txt", help="Reader centers text file")
     parser.add_argument("ts_csv", help="Timestamps CSV for alignment")
     parser.add_argument("--shuffle", type=int, default=1, help="DLC shuffle index")
-    parser.add_argument("--track_method", default="ellipse", help="Tracklet matching method")
-    parser.add_argument("--destfolder", default=None, help="Output directory for intermediates")
-    parser.add_argument("--trainingsetindex", type=int, default=0, help="DLC training set index")
-    parser.add_argument("--output_video", default=None, help="Path for final overlay video")
+    parser.add_argument(
+        "--track_method", default="ellipse", help="Tracklet matching method"
+    )
+    parser.add_argument(
+        "--destfolder",
+        default=cfg.DESTFOLDER,
+        help="Output directory for intermediates",
+    )
+    parser.add_argument(
+        "--trainingsetindex", type=int, default=0, help="DLC training set index"
+    )
+    parser.add_argument(
+        "--output_video", default=None, help="Path for final overlay video"
+    )
     parser.add_argument(
         "--config_override",
         default=None,

--- a/deeplabcut/rfid_tracking/scripts/run_full_pipeline.py
+++ b/deeplabcut/rfid_tracking/scripts/run_full_pipeline.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Run the entire RFID tracking pipeline with preset paths."""
 
+from deeplabcut.rfid_tracking import config as cfg
 from deeplabcut.rfid_tracking.pipeline import run_pipeline
 
 # Update these paths to match your environment
@@ -9,6 +10,7 @@ VIDEO_PATH = "/data/myproject/video.mp4"
 RFID_CSV = "/data/myproject/rfid_events.csv"
 CENTERS_TXT = "/data/myproject/readers_centers.txt"
 TS_CSV = "/data/myproject/timestamps.csv"
+DESTFOLDER = cfg.DESTFOLDER  # Optional output dir; overrides ``config.DESTFOLDER``
 
 
 def main() -> None:
@@ -19,6 +21,7 @@ def main() -> None:
         rfid_csv=RFID_CSV,
         centers_txt=CENTERS_TXT,
         ts_csv=TS_CSV,
+        destfolder=DESTFOLDER,
     )
 
 


### PR DESCRIPTION
## Summary
- add `DESTFOLDER` setting to RFID tracking config
- default `destfolder` CLI arg to `cfg.DESTFOLDER`
- expose `cfg.DESTFOLDER` in pipeline, example script, and docs

## Testing
- `pre-commit run --files deeplabcut/rfid_tracking/config.py deeplabcut/rfid_tracking/run_pipeline.py deeplabcut/rfid_tracking/pipeline.py deeplabcut/rfid_tracking/scripts/run_full_pipeline.py deeplabcut/rfid_tracking/README.md`
- `pytest deeplabcut/rfid_tracking`

------
https://chatgpt.com/codex/tasks/task_e_68b003759b7c8322868e6cc99bf3f421