### PR TITLE
feat: allow overriding coil diameter for RFID matching

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -74,7 +74,8 @@ run_rfid_pipeline(
 ```
 
 如果在 `config.py` 中设置了 ``DESTFOLDER``，命令行运行 `run_pipeline.py`
-时可通过 `--destfolder` 参数覆盖该默认目录。
+时可通过 `--destfolder` 参数覆盖该默认目录；`--mrt_coil_diameter_px`
+可临时设置线圈直径（像素）。
 
 该函数依次调用：
 
@@ -101,6 +102,7 @@ python convert_detection2tracklets.py --config-path <项目config.yaml> --video-
 # 在 config.py 中设置 MRT_* 路径或提供 YAML 覆盖
 python match_rfid_to_tracklets.py                # 使用 config.py 中的默认值
 python match_rfid_to_tracklets.py --config my_mrt.yaml  # 读取外部 YAML
+python match_rfid_to_tracklets.py --mrt_coil_diameter_px 120  # 临时覆盖线圈直径
 ```
 
 示例 YAML (`my_mrt.yaml`):
@@ -173,6 +175,7 @@ python scripts/run_make_video.py       # 生成可视化视频
 ### match_rfid_to_tracklets 参数
 - `MRT_PICKLE_PATH` / `MRT_RFID_CSV` / `MRT_CENTERS_TXT` / `MRT_TS_CSV` / `MRT_OUT_DIR`
 - `MRT_HIT_RADIUS_PX`、`MRT_AMBIG_MARGIN_PX`、`MRT_TAG_CONFIDENCE_THRESHOLD` 等匹配门槛
+- `MRT_COIL_DIAMETER_PX`：线圈直径（像素）；命令行 `run_pipeline.py` 和 `match_rfid_to_tracklets.py` 可通过 `--mrt_coil_diameter_px` 覆盖
 
 这些参数可直接在 `config.py` 中修改，或写入 YAML 后通过
 `python match_rfid_to_tracklets.py --config my_mrt.yaml` 加载。
@@ -220,7 +223,8 @@ DRAW_READERS: false
 ```bash
 python run_pipeline.py config.yaml video.mp4 rfid.csv centers.txt ts.csv \
     --destfolder ./outputs \
-    --config_override my_config.yaml
+    --config_override my_config.yaml \
+    --mrt_coil_diameter_px 120
 ```
 
 ## 数据格式

--- a/deeplabcut/rfid_tracking/match_rfid_to_tracklets.py
+++ b/deeplabcut/rfid_tracking/match_rfid_to_tracklets.py
@@ -457,9 +457,12 @@ def main(
     ts_csv: str | None = None,
     out_dir: str | None = None,
     config_path: str | None = None,
+    mrt_coil_diameter_px: float | None = None,
 ) -> None:
     if config_path:
         cfg.load_mrt_config(config_path)
+    if mrt_coil_diameter_px is not None:
+        cfg.MRT_COIL_DIAMETER_PX = mrt_coil_diameter_px
     refresh_from_config()
 
     pickle_path = pickle_path or PICKLE_PATH
@@ -862,5 +865,11 @@ if __name__ == "__main__":
     parser.add_argument("--ts", dest="ts_csv", default=None, help="Timestamps CSV file")
     parser.add_argument(
         "--out_dir", dest="out_dir", default=None, help="Directory for output files"
+    )
+    parser.add_argument(
+        "--mrt_coil_diameter_px",
+        type=float,
+        default=None,
+        help="RFID coil diameter in pixels; overrides MRT_COIL_DIAMETER_PX",
     )
     main(**vars(parser.parse_args()))

--- a/deeplabcut/rfid_tracking/run_pipeline.py
+++ b/deeplabcut/rfid_tracking/run_pipeline.py
@@ -42,8 +42,18 @@ def main() -> None:
         default=None,
         help="YAML file to override rfid_tracking.config settings",
     )
+    parser.add_argument(
+        "--mrt_coil_diameter_px",
+        type=float,
+        default=None,
+        help="RFID coil diameter in pixels; overrides cfg.MRT_COIL_DIAMETER_PX",
+    )
     args = parser.parse_args()
-    run_pipeline(**vars(args))
+    if args.mrt_coil_diameter_px is not None:
+        cfg.MRT_COIL_DIAMETER_PX = args.mrt_coil_diameter_px
+    params = vars(args)
+    params.pop("mrt_coil_diameter_px", None)
+    run_pipeline(**params)
 
 
 if __name__ == "__main__":

--- a/deeplabcut/rfid_tracking/scripts/run_full_pipeline.py
+++ b/deeplabcut/rfid_tracking/scripts/run_full_pipeline.py
@@ -11,6 +11,7 @@ RFID_CSV = "/data/myproject/rfid_events.csv"
 CENTERS_TXT = "/data/myproject/readers_centers.txt"
 TS_CSV = "/data/myproject/timestamps.csv"
 DESTFOLDER = cfg.DESTFOLDER  # Optional output dir; overrides ``config.DESTFOLDER``
+MRT_COIL_DIAMETER_PX = cfg.MRT_COIL_DIAMETER_PX  # Override coil diameter if needed
 
 
 def main() -> None:
@@ -22,6 +23,7 @@ def main() -> None:
         centers_txt=CENTERS_TXT,
         ts_csv=TS_CSV,
         destfolder=DESTFOLDER,
+        mrt_coil_diameter_px=MRT_COIL_DIAMETER_PX,
     )
 
 

--- a/deeplabcut/rfid_tracking/scripts/run_match_rfid.py
+++ b/deeplabcut/rfid_tracking/scripts/run_match_rfid.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Match RFID readings to tracklets using preset file locations."""
 
+from deeplabcut.rfid_tracking import config as cfg
 from deeplabcut.rfid_tracking.match_rfid_to_tracklets import main as match_rfid
 
 # Default paths used in our local setup
@@ -9,6 +10,7 @@ RFID_CSV = "/data/myproject/rfid_events.csv"
 CENTERS_TXT = "/data/myproject/readers_centers.txt"
 TS_CSV = "/data/myproject/timestamps.csv"
 OUT_DIR = "/data/myproject/rfid_match_outputs"
+MRT_COIL_DIAMETER_PX = cfg.MRT_COIL_DIAMETER_PX  # Override coil diameter if needed
 
 
 def main() -> None:
@@ -19,6 +21,7 @@ def main() -> None:
         centers_txt=CENTERS_TXT,
         ts_csv=TS_CSV,
         out_dir=OUT_DIR,
+        mrt_coil_diameter_px=MRT_COIL_DIAMETER_PX,
     )
 
 


### PR DESCRIPTION
## Summary
- add `--mrt_coil_diameter_px` CLI option to RFID pipeline and matching scripts
- support overriding coil diameter in example scripts
- document new flag in RFID README

## Testing
- `pre-commit run --files deeplabcut/rfid_tracking/run_pipeline.py deeplabcut/rfid_tracking/match_rfid_to_tracklets.py deeplabcut/rfid_tracking/scripts/run_full_pipeline.py deeplabcut/rfid_tracking/scripts/run_match_rfid.py deeplabcut/rfid_tracking/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68b0079d0cdc8322820939b2282f02fb