### PR TITLE
Use config-defined path for RFID reconstruction output

### DIFF
--- a/deeplabcut/rfid_tracking/pipeline.py
+++ b/deeplabcut/rfid_tracking/pipeline.py
@@ -8,7 +8,8 @@ from . import config as cfg
 from .make_video import main as make_video
 from .match_rfid_to_tracklets import main as match_rfid_to_tracklets
 from .reconstruct_from_pickle import main as reconstruct_from_pickle
-from .reconstruct_from_pickle import OUT_SUBDIR as RECON_OUT_SUBDIR
+
+RECON_OUT_SUBDIR = cfg.OUT_SUBDIR
 
 logger = logging.getLogger(__name__)
 
@@ -145,9 +146,9 @@ def run_pipeline(
     logger.info("Finished converting detections to tracklets for %s", video_path)
 
     # Locate the generated tracklet pickle
-    cfg = aux.read_config(config_path)
-    train_fraction = cfg["TrainingFraction"][trainingsetindex]
-    dlc_scorer = get_scorer_name(cfg, shuffle, train_fraction)[0]
+    dlc_cfg = aux.read_config(config_path)
+    train_fraction = dlc_cfg["TrainingFraction"][trainingsetindex]
+    dlc_scorer = get_scorer_name(dlc_cfg, shuffle, train_fraction)[0]
     method_suffix = {"ellipse": "el", "box": "bx"}.get(track_method, "sk")
     track_pickle = dest / f"{video_path.stem}{dlc_scorer}_{method_suffix}.pickle"
 


### PR DESCRIPTION
## Summary
- Define `RECON_OUT_SUBDIR` from `rfid_tracking.config` instead of `reconstruct_from_pickle`
- Pass `RECON_OUT_SUBDIR` to `reconstruct_from_pickle` during pipeline execution
- Avoid shadowing config module in `run_pipeline`

## Testing
- `python -m deeplabcut.rfid_tracking.run_pipeline --help`
- `PYTHONPATH=. pytest tests/test_auxiliaryfunctions.py::test_find_analyzed_data -q`
- `ruff check deeplabcut/rfid_tracking/pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68b00e3025ec8322a07bf9eb319276f8