### PR TITLE
Allow configurable RFID match output directory

### DIFF
--- a/deeplabcut/rfid_tracking/config.py
+++ b/deeplabcut/rfid_tracking/config.py
@@ -71,7 +71,12 @@ MRT_PICKLE_PATH = PICKLE_IN
 MRT_RFID_CSV = PROJECT_ROOT / "analysis/data/jc0813/rfid_data_20250813_055827.csv"
 MRT_CENTERS_TXT = CENTERS_TXT
 MRT_TS_CSV = PROJECT_ROOT / "analysis/data/jc0813/record_20250813_053913_timestamps.csv"
-MRT_OUT_DIR = PROJECT_ROOT / "analysis/data/jc0813/rfid_match_outputs"
+_mrt_base = PROJECT_ROOT / "analysis/data/jc0813"
+MRT_OUT_DIR = (
+    _mrt_base / OUT_SUBDIR / "rfid_match_outputs"
+    if OUT_SUBDIR
+    else _mrt_base / "rfid_match_outputs"
+)
 
 MRT_N_ROWS = 12
 MRT_N_COLS = 12


### PR DESCRIPTION
## Summary
- allow setting RFID match outputs under per-subdir folders when OUT_SUBDIR is defined

## Testing
- `pre-commit run --files deeplabcut/rfid_tracking/config.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'tensorflow')*


------
https://chatgpt.com/codex/tasks/task_e_68b03207bf108322898c4067a9b49b16