### PR TITLE
Only draw trailpoints for valid previous frames

### DIFF
--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -211,12 +211,17 @@ def CreateVideo(
                         color = colors[num_ind]
                     if trailpoints > 0:
                         for k in range(1, min(trailpoints, index + 1)):
-                            rr, cc = disk(
-                                (df_y[ind, index - k], df_x[ind, index - k]),
-                                dotsize,
-                                shape=(ny, nx),
-                            )
-                            image[rr, cc] = color
+                            if (
+                                df_likelihood[ind, index - k] > pcutoff
+                                and ~np.isnan(df_x[ind, index - k])
+                                and ~np.isnan(df_y[ind, index - k])
+                            ):
+                                rr, cc = disk(
+                                    (df_y[ind, index - k], df_x[ind, index - k]),
+                                    dotsize,
+                                    shape=(ny, nx),
+                                )
+                                image[rr, cc] = color
                     rr, cc = disk(
                         (df_y[ind, index], df_x[ind, index]), dotsize, shape=(ny, nx)
                     )


### PR DESCRIPTION
## Summary
- Skip drawing trail segments when the previous frame's likelihood is below `pcutoff` or coordinates are NaN, preventing spurious trails

## Testing
- `PYTHONPATH=$PWD pytest tests/test_video.py` *(fails: AssertionError and missing video dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b07169e74083228faf9003cd61a9d4