### PR TITLE
Add optional output subdirectory for RFID tracking pipeline

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -69,13 +69,21 @@ run_rfid_pipeline(
     rfid_csv="path/to/rfid.csv",
     centers_txt="path/to/readers_centers.txt",
     ts_csv="path/to/timestamps.csv",
-    destfolder="path/to/output"  # 可选；若省略则使用 ``config.DESTFOLDER``
+    destfolder="path/to/output",  # 可选；若省略则使用 ``config.DESTFOLDER``
+    out_subdir="session1",        # 可选；子目录，不填则直接写入目标目录
 )
 ```
 
 如果在 `config.py` 中设置了 ``DESTFOLDER``，命令行运行 `run_pipeline.py`
-时可通过 `--destfolder` 参数覆盖该默认目录；`--mrt_coil_diameter_px`
-可临时设置线圈直径（像素）。
+时可通过 `--destfolder` 参数覆盖该默认目录；使用 `--out-subdir` 可
+指定在目标目录下创建子目录，省略该参数则结果直接写入目标目录。
+`--mrt_coil_diameter_px` 可临时设置线圈直径（像素）。
+
+示例命令行：
+```bash
+python run_pipeline.py config.yaml video.mp4 rfid.csv centers.txt ts.csv \
+    --destfolder path/to/output --out-subdir session1
+```
 
 该函数依次调用：
 

--- a/deeplabcut/rfid_tracking/config.py
+++ b/deeplabcut/rfid_tracking/config.py
@@ -11,15 +11,16 @@ BASE_DIR = Path(__file__).resolve().parent
 # 路径可根据实际项目调整
 PICKLE_IN = None
 PICKLE_OUT = None  # None 表示覆盖输入
-OUT_SUBDIR = "cap15"  # 输出子目录; 设为 None 则直接写入同级目录
+OUT_SUBDIR = None  # 输出子目录; 设为 None 则直接写入同级目录
 _dest = os.environ.get("DESTFOLDER")
 DESTFOLDER = Path(_dest) if _dest else None  # 中间结果输出目录; None 则使用视频所在目录
 
 VIDEO_PATH = PROJECT_ROOT / "deeplabcut/videos/test/demo.mp4"
 PICKLE_PATH = PICKLE_IN  # make_video 默认使用同一 pickle
 OUTPUT_VIDEO = (
-    PROJECT_ROOT
-    / "deeplabcut/projects/MiceTrackerFor20-Oppa-2024-12-08/analyze_videos/shuffle3/demo1/velocity_gating/CAP15/demo_tracked.mp4"
+    (DESTFOLDER / OUT_SUBDIR / f"{VIDEO_PATH.stem}_tracked.mp4")
+    if DESTFOLDER and OUT_SUBDIR
+    else (DESTFOLDER / f"{VIDEO_PATH.stem}_tracked.mp4" if DESTFOLDER else None)
 )
 
 CENTERS_TXT = PROJECT_ROOT / "analysis/data/jc0813/readers_centers.txt"

--- a/deeplabcut/rfid_tracking/run_pipeline.py
+++ b/deeplabcut/rfid_tracking/run_pipeline.py
@@ -32,6 +32,11 @@ def main() -> None:
         help="Output directory for intermediates",
     )
     parser.add_argument(
+        "--out-subdir",
+        default=cfg.OUT_SUBDIR,
+        help="Subdirectory within destfolder for intermediate and final outputs",
+    )
+    parser.add_argument(
         "--trainingsetindex", type=int, default=0, help="DLC training set index"
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- allow configuring output subdirectory via `OUT_SUBDIR` or `--out-subdir`
- propagate subdirectory through pipeline to place intermediates and final video
- document out-subdir usage in RFID tracking README

## Testing
- `pre-commit run --files deeplabcut/rfid_tracking/config.py deeplabcut/rfid_tracking/run_pipeline.py deeplabcut/rfid_tracking/pipeline.py deeplabcut/rfid_tracking/README.md`
- `pytest deeplabcut/rfid_tracking -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0b1ea5a448322aa7ff0bca2f1af65