### PR TITLE
refactor: externalize RFID tracking paths

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -59,6 +59,22 @@ project/
 
 ## 使用方法
 
+由于 `config.py` 中相关路径的默认值均为 `None`，运行前需通过命令行
+或 YAML 文件提供实际文件路径。下面给出一个最小示例：
+
+```yaml
+# paths.yaml
+VIDEO_PATH: /path/to/video.mp4
+MRT_RFID_CSV: /path/to/rfid.csv
+MRT_CENTERS_TXT: /path/to/readers_centers.txt
+MRT_TS_CSV: /path/to/timestamps.csv
+```
+
+```bash
+python run_pipeline.py config.yaml /path/to/video.mp4 /path/to/rfid.csv \
+    /path/to/readers_centers.txt /path/to/timestamps.csv --config_override paths.yaml
+```
+
 ### 一键全流程分析
 ```python
 from deeplabcut import run_rfid_pipeline

--- a/deeplabcut/rfid_tracking/config.py
+++ b/deeplabcut/rfid_tracking/config.py
@@ -3,27 +3,24 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-PROJECT_ROOT = Path("/ssd01/user_acc_data/oppa")
+_project_root = os.environ.get("PROJECT_ROOT")
 # Base directory for RFID tracking scripts
+PROJECT_ROOT = Path(_project_root) if _project_root else Path.cwd()
 BASE_DIR = Path(__file__).resolve().parent
 
 # ================== 默认路径 ==================
-# 路径可根据实际项目调整
+# 路径需通过命令行或 YAML 覆盖
 PICKLE_IN = None
 PICKLE_OUT = None  # None 表示覆盖输入
 OUT_SUBDIR = None  # 输出子目录; 设为 None 则直接写入同级目录
 _dest = os.environ.get("DESTFOLDER")
 DESTFOLDER = Path(_dest) if _dest else None  # 中间结果输出目录; None 则使用视频所在目录
 
-VIDEO_PATH = PROJECT_ROOT / "deeplabcut/videos/test/demo.mp4"
-PICKLE_PATH = PICKLE_IN  # make_video 默认使用同一 pickle
-OUTPUT_VIDEO = (
-    (DESTFOLDER / OUT_SUBDIR / f"{VIDEO_PATH.stem}_tracked.mp4")
-    if DESTFOLDER and OUT_SUBDIR
-    else (DESTFOLDER / f"{VIDEO_PATH.stem}_tracked.mp4" if DESTFOLDER else None)
-)
+VIDEO_PATH = None  # 视频文件路径，需通过命令行或 YAML 指定
+PICKLE_PATH = None  # make_video 使用的 pickle 文件路径，需指定
+OUTPUT_VIDEO = None  # 输出视频路径，未指定则在运行时生成
 
-CENTERS_TXT = PROJECT_ROOT / "analysis/data/jc0813/readers_centers.txt"
+CENTERS_TXT = None  # RFID 读写器中心坐标文件，需指定
 ROI_FILE = (
     PROJECT_ROOT / "analysis/rfid_dlc_tracking/version2_tracking/roi_definitions.json"
 )
@@ -71,9 +68,9 @@ MAX_FRAMES = None
 # ================== match_rfid_to_tracklets 默认参数 ==================
 # 路径可在此修改，或通过 load_mrt_config 从 YAML 覆盖
 MRT_PICKLE_PATH = PICKLE_IN
-MRT_RFID_CSV = PROJECT_ROOT / "analysis/data/jc0813/rfid_data_20250813_055827.csv"
-MRT_CENTERS_TXT = CENTERS_TXT
-MRT_TS_CSV = PROJECT_ROOT / "analysis/data/jc0813/record_20250813_053913_timestamps.csv"
+MRT_RFID_CSV = None  # RFID 事件 CSV，需通过命令行或 YAML 指定
+MRT_CENTERS_TXT = None  # 读写器中心坐标文件，需指定
+MRT_TS_CSV = None  # 时间戳 CSV，需指定
 MRT_OUT_DIR = (
     DESTFOLDER / OUT_SUBDIR / "rfid_match_outputs"
     if DESTFOLDER and OUT_SUBDIR

--- a/deeplabcut/rfid_tracking/pipeline.py
+++ b/deeplabcut/rfid_tracking/pipeline.py
@@ -80,25 +80,55 @@ def run_pipeline(
 
     cfg.load_config(config_override)
 
+    if config_path is None:
+        raise ValueError(
+            "config_path is required; provide via command line or configuration file"
+        )
     config_path = Path(config_path)
     if not config_path.exists():
         raise FileNotFoundError(f"Config file not found: {config_path}")
 
+    if video_path is None:
+        raise ValueError(
+            "video_path is required; provide via command line or configuration file"
+        )
     video_path = Path(video_path)
     if not video_path.exists():
         raise FileNotFoundError(f"Video file not found: {video_path}")
 
-    rfid_csv = Path(rfid_csv) if rfid_csv is not None else Path(cfg.MRT_RFID_CSV)
+    rfid_csv = (
+        Path(rfid_csv)
+        if rfid_csv is not None
+        else (Path(cfg.MRT_RFID_CSV) if cfg.MRT_RFID_CSV is not None else None)
+    )
+    if rfid_csv is None:
+        raise ValueError(
+            "rfid_csv is None; specify path via command line or set MRT_RFID_CSV in config"
+        )
     if not rfid_csv.exists():
         raise FileNotFoundError(f"RFID CSV file not found: {rfid_csv}")
 
     centers_txt = (
-        Path(centers_txt) if centers_txt is not None else Path(cfg.MRT_CENTERS_TXT)
+        Path(centers_txt)
+        if centers_txt is not None
+        else (Path(cfg.MRT_CENTERS_TXT) if cfg.MRT_CENTERS_TXT is not None else None)
     )
+    if centers_txt is None:
+        raise ValueError(
+            "centers_txt is None; specify path via command line or set MRT_CENTERS_TXT in config"
+        )
     if not centers_txt.exists():
         raise FileNotFoundError(f"Reader centers file not found: {centers_txt}")
 
-    ts_csv = Path(ts_csv) if ts_csv is not None else Path(cfg.MRT_TS_CSV)
+    ts_csv = (
+        Path(ts_csv)
+        if ts_csv is not None
+        else (Path(cfg.MRT_TS_CSV) if cfg.MRT_TS_CSV is not None else None)
+    )
+    if ts_csv is None:
+        raise ValueError(
+            "ts_csv is None; specify path via command line or set MRT_TS_CSV in config"
+        )
     if not ts_csv.exists():
         raise FileNotFoundError(f"Timestamps CSV file not found: {ts_csv}")
 

--- a/deeplabcut/rfid_tracking/配置详情.md
+++ b/deeplabcut/rfid_tracking/配置详情.md
@@ -1,5 +1,5 @@
 路径类参数
-PROJECT_ROOT：项目根目录，其他路径多以此为基准
+PROJECT_ROOT：项目根目录，默认为当前工作目录，可通过环境变量 `PROJECT_ROOT` 指定
 
 BASE_DIR：config.py 所在目录
 
@@ -7,13 +7,13 @@ PICKLE_IN / PICKLE_OUT：轨迹数据（pickle）输入与输出路径，None �
 
 OUT_SUBDIR：结果输出子目录，None 则直接输出到同级目录
 
-VIDEO_PATH：视频文件路径
+VIDEO_PATH：视频文件路径，默认 `None`，需手动提供
 
-PICKLE_PATH：make_video 默认使用的 pickle 路径
+PICKLE_PATH：make_video 默认使用的 pickle 路径，默认 `None`
 
-OUTPUT_VIDEO：轨迹可视化输出视频路径
+OUTPUT_VIDEO：轨迹可视化输出视频路径，默认 `None`
 
-CENTERS_TXT：RFID 读写器中心坐标文件
+CENTERS_TXT：RFID 读写器中心坐标文件，默认 `None`
 
 ROI_FILE：ROI 定义 JSON
 
@@ -54,11 +54,11 @@ MAX_FRAMES：最多绘制的帧数
 match_rfid_to_tracklets 专用参数（MRT_*）
 MRT_PICKLE_PATH：轨迹 pickle
 
-MRT_RFID_CSV：RFID 读写数据 CSV
+MRT_RFID_CSV：RFID 读写数据 CSV，默认 `None`
 
-MRT_CENTERS_TXT：读写器中心坐标
+MRT_CENTERS_TXT：读写器中心坐标，默认 `None`
 
-MRT_TS_CSV：时间戳 CSV
+MRT_TS_CSV：时间戳 CSV，默认 `None`
 
 MRT_OUT_DIR：匹配结果输出目录
 


### PR DESCRIPTION
## Summary
- default RFID tracking paths to `None` and pick project root from env or CWD
- raise clear errors when required paths are missing in `pipeline.run_pipeline`
- document minimal configuration example in RFID README

## Testing
- `pre-commit run --files deeplabcut/rfid_tracking/config.py deeplabcut/rfid_tracking/pipeline.py deeplabcut/rfid_tracking/README.md deeplabcut/rfid_tracking/配置详情.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'deeplabcut')*

------
https://chatgpt.com/codex/tasks/task_e_68b0b35d269883229b47b9dc6271ac3d