### PR TITLE
Add CLI scripts for RFID pipeline steps and expand README

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -2,6 +2,17 @@
 
 这是一个基于DeepLabCut和RFID技术的动物行为追踪分析项目，用于重建动物移动轨迹并生成可视化视频。
 
+## 快速开始
+
+仓库自带了一套简短的示例数据（DLC 模型、视频、RFID 记录等），解压后可直接体验全流程：
+
+```bash
+python scripts/run_full_pipeline.py demo/config.yaml demo/video.mp4 demo/rfid.csv \
+    demo/readers_centers.txt demo/timestamps.csv --out-subdir demo_output
+```
+
+要在自己的数据上运行，只需将上述路径替换为实际文件位置；命令默认会在输出目录下创建可视化视频。
+
 ## 项目结构
 
 ```
@@ -122,11 +133,11 @@ python convert_detection2tracklets.py --config-path <项目config.yaml> --video-
 - `--videotype`：目录模式下的视频后缀
 
 ### 1. RFID 与 tracklet 匹配
+可单独调用 `scripts/run_match_rfid.py` 并显式提供路径：
+
 ```bash
-# 在 config.py 中设置 MRT_* 路径或提供 YAML 覆盖
-python match_rfid_to_tracklets.py                # 使用 config.py 中的默认值
-python match_rfid_to_tracklets.py --config my_mrt.yaml  # 读取外部 YAML
-python match_rfid_to_tracklets.py --mrt_coil_diameter_px 120  # 临时覆盖线圈直径
+python scripts/run_match_rfid.py tracklets.pickle rfid.csv readers_centers.txt \
+    timestamps.csv --out-dir rfid_match_outputs
 ```
 
 示例 YAML (`my_mrt.yaml`):
@@ -140,8 +151,8 @@ MRT_OUT_DIR: ./rfid_match_outputs
 
 ### 2. 轨迹重建
 ```bash
-# 根据实际情况修改 config.py 中的路径与门控参数
-python reconstruct_from_pickle.py
+python scripts/run_reconstruct.py tracklets_with_rfid.pickle \
+    --pickle-out reconstructed.pickle --out-subdir recon
 ```
 
 输出文件：
@@ -150,25 +161,28 @@ python reconstruct_from_pickle.py
 
 ### 3. 视频生成
 ```bash
-# 根据实际情况修改 config.py 中的路径与可视化参数
-python make_video.py
+python scripts/run_make_video.py video.mp4 reconstructed.pickle readers_centers.txt \
+    --output-video rfid_tracklets_overlay.mp4
 ```
 
 输出文件：
 - `rfid_tracklets_overlay.mp4`：可视化视频
 
 ## 示例脚本
-
-`scripts/` 目录提供了带有示例路径的便捷运行脚本，可快速测试各个步骤：
+`scripts/` 目录中的脚本均已支持命令行参数，可作为最小示例直接运行：
 
 ```bash
-python scripts/run_full_pipeline.py    # 运行完整流程
-python scripts/run_match_rfid.py       # 仅进行 RFID 匹配
-python scripts/run_reconstruct.py      # 轨迹重建
-python scripts/run_make_video.py       # 生成可视化视频
-```
+# 运行完整流程（支持 --out-subdir）
+python scripts/run_full_pipeline.py config.yaml video.mp4 rfid.csv \
+    readers_centers.txt timestamps.csv --destfolder outputs --out-subdir session1
 
-运行前请根据实际文件位置修改脚本顶部的常量。
+# 单独执行各步骤
+python scripts/run_match_rfid.py tracklets.pickle rfid.csv readers_centers.txt \
+    timestamps.csv --out-dir rfid_match_outputs
+python scripts/run_reconstruct.py tracklets_with_rfid.pickle --out-subdir recon
+python scripts/run_make_video.py video.mp4 reconstructed.pickle readers_centers.txt \
+    --output-video overlay.mp4
+```
 
 ## 配置参数
 

--- a/deeplabcut/rfid_tracking/scripts/run_full_pipeline.py
+++ b/deeplabcut/rfid_tracking/scripts/run_full_pipeline.py
@@ -1,31 +1,56 @@
 #!/usr/bin/env python3
-"""Run the entire RFID tracking pipeline with preset paths."""
+"""Example CLI for running the complete RFID tracking pipeline."""
 
-from deeplabcut.rfid_tracking import config as cfg
+from __future__ import annotations
+
+import argparse
+
 from deeplabcut.rfid_tracking.pipeline import run_pipeline
 
-# Update these paths to match your environment
-CONFIG_PATH = "/data/myproject/config.yaml"
-VIDEO_PATH = "/data/myproject/video.mp4"
-RFID_CSV = "/data/myproject/rfid_events.csv"
-CENTERS_TXT = "/data/myproject/readers_centers.txt"
-TS_CSV = "/data/myproject/timestamps.csv"
-DESTFOLDER = cfg.DESTFOLDER  # Optional output dir; overrides ``config.DESTFOLDER``
-MRT_COIL_DIAMETER_PX = cfg.MRT_COIL_DIAMETER_PX  # Override coil diameter if needed
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the full RFID tracking pipeline",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("config_path", help="Path to DLC project config.yaml")
+    parser.add_argument("video_path", help="Video file to analyze")
+    parser.add_argument("rfid_csv", help="RFID events CSV file")
+    parser.add_argument("centers_txt", help="Reader centers text file")
+    parser.add_argument("ts_csv", help="Timestamp CSV used for alignment")
+    parser.add_argument("--destfolder", default=None, help="Output directory")
+    parser.add_argument(
+        "--out-subdir",
+        default=None,
+        help="Subdirectory inside destfolder for intermediate outputs",
+    )
+    parser.add_argument("--shuffle", type=int, default=1, help="DLC shuffle index")
+    parser.add_argument(
+        "--track-method",
+        default="ellipse",
+        help="Tracklet matching method (ellipse, skeleton, box)",
+    )
+    parser.add_argument(
+        "--trainingsetindex", type=int, default=0, help="DLC training set index"
+    )
+    parser.add_argument(
+        "--output-video",
+        default=None,
+        help="Path for final overlay video (defaults to auto naming)",
+    )
+    parser.add_argument(
+        "--config-override",
+        default=None,
+        help="YAML file to override rfid_tracking.config settings",
+    )
+    return parser
 
 
 def main() -> None:
-    """Execute :func:`run_pipeline` with default arguments."""
-    run_pipeline(
-        config_path=CONFIG_PATH,
-        video_path=VIDEO_PATH,
-        rfid_csv=RFID_CSV,
-        centers_txt=CENTERS_TXT,
-        ts_csv=TS_CSV,
-        destfolder=DESTFOLDER,
-        mrt_coil_diameter_px=MRT_COIL_DIAMETER_PX,
-    )
+    args = build_argparser().parse_args()
+    run_pipeline(**vars(args))
 
 
 if __name__ == "__main__":
     main()
+

--- a/deeplabcut/rfid_tracking/scripts/run_make_video.py
+++ b/deeplabcut/rfid_tracking/scripts/run_make_video.py
@@ -1,23 +1,44 @@
 #!/usr/bin/env python3
-"""Create a visualization video with preset file paths."""
+"""CLI wrapper to generate an RFID overlay video."""
+
+from __future__ import annotations
+
+import argparse
 
 from deeplabcut.rfid_tracking.make_video import main as make_video
 
-VIDEO_PATH = "/data/myproject/video.mp4"
-PICKLE_PATH = "/data/myproject/reconstructed_tracklets.pickle"
-CENTERS_TXT = "/data/myproject/readers_centers.txt"
-OUTPUT_VIDEO = "/data/myproject/output_overlay.mp4"
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Create a visualization video with RFID and tracklets",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("video_path", help="Input video file")
+    parser.add_argument(
+        "pickle_path",
+        help="Tracklet pickle with reconstruction and RFID information",
+    )
+    parser.add_argument(
+        "centers_txt", help="Reader centers text file used for visualization"
+    )
+    parser.add_argument(
+        "--output-video",
+        default="./rfid_tracklets_overlay.mp4",
+        help="Path for the generated overlay video",
+    )
+    return parser
 
 
 def main() -> None:
-    """Invoke :func:`make_video` using default arguments."""
+    args = build_argparser().parse_args()
     make_video(
-        video_path=VIDEO_PATH,
-        pickle_path=PICKLE_PATH,
-        centers_txt=CENTERS_TXT,
-        output_video=OUTPUT_VIDEO,
+        video_path=args.video_path,
+        pickle_path=args.pickle_path,
+        centers_txt=args.centers_txt,
+        output_video=args.output_video,
     )
 
 
 if __name__ == "__main__":
     main()
+

--- a/deeplabcut/rfid_tracking/scripts/run_match_rfid.py
+++ b/deeplabcut/rfid_tracking/scripts/run_match_rfid.py
@@ -1,29 +1,49 @@
 #!/usr/bin/env python3
-"""Match RFID readings to tracklets using preset file locations."""
+"""CLI wrapper to match RFID readings to tracklets."""
+
+from __future__ import annotations
+
+import argparse
 
 from deeplabcut.rfid_tracking import config as cfg
 from deeplabcut.rfid_tracking.match_rfid_to_tracklets import main as match_rfid
 
-# Default paths used in our local setup
-PICKLE_PATH = "/data/myproject/tracklets.pickle"
-RFID_CSV = "/data/myproject/rfid_events.csv"
-CENTERS_TXT = "/data/myproject/readers_centers.txt"
-TS_CSV = "/data/myproject/timestamps.csv"
-OUT_DIR = "/data/myproject/rfid_match_outputs"
-MRT_COIL_DIAMETER_PX = cfg.MRT_COIL_DIAMETER_PX  # Override coil diameter if needed
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Match RFID events to DLC tracklets",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("pickle_path", help="Tracklets pickle file")
+    parser.add_argument("rfid_csv", help="RFID events CSV file")
+    parser.add_argument("centers_txt", help="Reader centers text file")
+    parser.add_argument("ts_csv", help="Timestamps CSV used for alignment")
+    parser.add_argument(
+        "--out-dir",
+        default="./rfid_match_outputs",
+        help="Directory to store matching outputs",
+    )
+    parser.add_argument(
+        "--mrt-coil-diameter-px",
+        type=float,
+        default=None,
+        help="RFID coil diameter in pixels (overrides cfg.MRT_COIL_DIAMETER_PX)",
+    )
+    return parser
 
 
 def main() -> None:
-    """Execute :func:`match_rfid` with the predefined parameters."""
+    args = build_argparser().parse_args()
     match_rfid(
-        pickle_path=PICKLE_PATH,
-        rfid_csv=RFID_CSV,
-        centers_txt=CENTERS_TXT,
-        ts_csv=TS_CSV,
-        out_dir=OUT_DIR,
-        mrt_coil_diameter_px=MRT_COIL_DIAMETER_PX,
+        pickle_path=args.pickle_path,
+        rfid_csv=args.rfid_csv,
+        centers_txt=args.centers_txt,
+        ts_csv=args.ts_csv,
+        out_dir=args.out_dir,
+        mrt_coil_diameter_px=args.mrt_coil_diameter_px,
     )
 
 
 if __name__ == "__main__":
     main()
+

--- a/deeplabcut/rfid_tracking/scripts/run_reconstruct.py
+++ b/deeplabcut/rfid_tracking/scripts/run_reconstruct.py
@@ -1,16 +1,41 @@
 #!/usr/bin/env python3
-"""Reconstruct trajectories from a pickle using preferred defaults."""
+"""CLI wrapper to reconstruct identity chains from a pickle."""
+
+from __future__ import annotations
+
+import argparse
 
 from deeplabcut.rfid_tracking.reconstruct_from_pickle import main as reconstruct
 
-PICKLE_IN = "/data/myproject/tracklets_with_rfid.pickle"
-PICKLE_OUT = "/data/myproject/reconstructed_tracklets.pickle"
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Reconstruct trajectories from a tracklet pickle",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("pickle_in", help="Input tracklets pickle with RFID tags")
+    parser.add_argument(
+        "--pickle-out",
+        default=None,
+        help="Path to save reconstructed pickle (defaults to overwrite input)",
+    )
+    parser.add_argument(
+        "--out-subdir",
+        default=None,
+        help="Optional subdirectory for outputs relative to input pickle",
+    )
+    return parser
 
 
 def main() -> None:
-    """Invoke :func:`reconstruct` with predefined paths."""
-    reconstruct(pickle_in=PICKLE_IN, pickle_out=PICKLE_OUT)
+    args = build_argparser().parse_args()
+    reconstruct(
+        pickle_in=args.pickle_in,
+        pickle_out=args.pickle_out,
+        out_subdir=args.out_subdir,
+    )
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- Replace hard-coded example scripts with argparse-based CLIs for RFID matching, reconstruction, video generation, and full pipeline
- Expand RFID tracking README with quick-start demo, per-step command examples, and `--out-subdir` workflow

## Testing
- `python -m py_compile deeplabcut/rfid_tracking/scripts/run_match_rfid.py deeplabcut/rfid_tracking/scripts/run_reconstruct.py deeplabcut/rfid_tracking/scripts/run_make_video.py deeplabcut/rfid_tracking/scripts/run_full_pipeline.py`
- `PYTHONPATH=. python deeplabcut/rfid_tracking/scripts/run_match_rfid.py --help`
- `PYTHONPATH=. python deeplabcut/rfid_tracking/scripts/run_reconstruct.py --help`
- `PYTHONPATH=. python deeplabcut/rfid_tracking/scripts/run_make_video.py --help`
- `PYTHONPATH=. python deeplabcut/rfid_tracking/scripts/run_full_pipeline.py --help`
- `pytest deeplabcut/rfid_tracking`

------
https://chatgpt.com/codex/tasks/task_e_68b0bd1517948322b148abe9e743566b