### PR TITLE
docs: remove duplicated run_pipeline example

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -267,14 +267,7 @@ DRAW_READERS: false
 ```
 
 在命令行运行全流程时，可使用 `--destfolder` 覆盖 `config.DESTFOLDER`，
-并通过 `--config_override` 传入该 YAML：
-
-```bash
-python run_pipeline.py config.yaml video.mp4 rfid.csv centers.txt ts.csv \
-    --destfolder ./outputs \
-    --config_override my_config.yaml \
-    --mrt_coil_diameter_px 120
-```
+并通过 `--config_override` 传入该 YAML（示例命令见前文）。
 
 ## 数据格式
 


### PR DESCRIPTION
## Summary
- avoid repeating run_pipeline command by referencing earlier example instead

## Testing
- `pre-commit run --files deeplabcut/rfid_tracking/README.md` *(command not found: pre-commit)*
- `pytest -q` *(fail: ModuleNotFoundError: No module named 'deeplabcut')*

------
https://chatgpt.com/codex/tasks/task_e_68b0dbc3a8b48322be11b811daf2407d