### PR TITLE
docs: expand RFID algorithm explanation

### DIFF
--- a/deeplabcut/rfid_tracking/README.md
+++ b/deeplabcut/rfid_tracking/README.md
@@ -76,6 +76,44 @@ project/
 - **可视化**：颜色生成、读卡器绘制、ROI绘制
 - **几何计算**：ROI命中测试、距离计算
 
+## 标签分配与轨迹重建原理
+
+### 标签分配原理
+`match_rfid_to_tracklets.py` 模块负责将读卡器逐次捕获到的标签分配给对应 tracklet。核心流程如下：
+
+1. **时空匹配**  
+   - 每条 RFID 记录首先根据 `MRT_RFID_FRAME_RANGE` 对齐到最近的视频帧；只有在这一帧及其前后给定帧数内出现的 tracklet 才会被考虑。  
+   - 以读卡器的几何中心为圆心，搜索半径为 `MRT_COIL_DIAMETER_PX / 2 + MRT_HIT_MARGIN` 的范围；候选轨迹需在圆内至少命中一次。
+
+2. **候选筛选**  
+   - 轨迹末端关键点的 `p` 值必须高于 `MRT_PCUTOFF`；  
+   - 若启用 `MRT_UNIQUE_NEIGHBOR_ONLY`，要求在该半径内只有唯一 tracklet；否则会比较最邻近的两个候选，若距离差小于 `MRT_AMBIG_MARGIN_PX` 则判为歧义。
+
+3. **标签确认**  
+   - 为每条 tracklet 统计各标签的命中次数，要求命中总数 ≥ `MRT_TAG_MIN_READS` 且主标签占比 ≥ `MRT_TAG_DOMINANT_RATIO`。  
+   - 对于低命中但高纯度的情况，可通过 `MRT_LOW_READS_HIGH_PURITY_ASSIGN` 与 `MRT_LOW_READS_PURITY_THRESHOLD` 进行宽松分配。  
+   - 最终把确认的标签写入节点的 `tag` 字段，同时记录 `rfid_counts` 和具体命中帧。
+
+### 轨迹重建原理
+`reconstruct_from_pickle.py` 以带标签的 tracklet 作为锚点，在整个时间轴上同步推进，构建连续的身份链：
+
+1. **锚点筛选**  
+   - 只有标签命中次数 ≥ `ANCHOR_MIN_HITS` 的 tracklet 才被视为可靠锚点；它们按照起始时间排序并作为“水源”同时向两侧扩散。
+
+2. **时间–速度门控**  
+   - 为每个活跃锚点计算其波前位置（头/尾中心）；仅在时间间隔 `≤ MAX_GAP_FRAMES` 且位移 `d ≤ V_GATE_CMS × gap / (FPS / PX_PER_CM)` 的候选 tracklet 才会被纳入候选池。  
+   - 候选的代价定义为 `d + EPS_GAP × gap`，越小越优先。
+
+3. **同步推进与冲突裁决**  
+   - 所有锚点同时提名各自代价最低的候选，如果同一个 tracklet 被多个锚点竞争，则按代价从小到大依次决策。  
+   - 若最佳与次佳代价之差小于 `δ = min(DELTA_PX_CAP, DELTA_PROP × 上限位移)`，则判为歧义并冻结该候选，等待下一轮。  
+   - 被选中的轨迹加入对应身份链，源锚点的波前移动到新轨迹末端；若某方向候选耗尽，则该波前终止。
+
+4. **近锚点堤坝**  
+   - 若同一标签在传播方向的 `MAX_GAP_FRAMES` 内已存在另一个锚点，则当前锚点不再越界扩张，以避免跨越可靠锚点造成错误连接。
+
+经过多轮推进后，所有波前都停止，最终得到多条无冲突的身份链，可用于后续可视化或行为分析。
+
 ## 使用方法
 
 由于 `config.py` 中相关路径的默认值均为 `None`，运行前需通过命令行
@@ -267,14 +305,7 @@ DRAW_READERS: false
 ```
 
 在命令行运行全流程时，可使用 `--destfolder` 覆盖 `config.DESTFOLDER`，
-并通过 `--config_override` 传入该 YAML：
-
-```bash
-python run_pipeline.py config.yaml video.mp4 rfid.csv centers.txt ts.csv \
-    --destfolder ./outputs \
-    --config_override my_config.yaml \
-    --mrt_coil_diameter_px 120
-```
+并通过 `--config_override` 传入该 YAML（示例命令见前文）。
 
 ## 数据格式
 


### PR DESCRIPTION
## Summary
- elaborate RFID tag matching procedure with spatial gating and confidence heuristics
- document wavefront-based trajectory reconstruction with time-speed gate and conflict resolution

## Testing
- `pre-commit run --files deeplabcut/rfid_tracking/README.md` (command not found: pre-commit)
- `pytest -q` (ModuleNotFoundError: No module named 'deeplabcut')

------
https://chatgpt.com/codex/tasks/task_e_68b0dbc3a8b48322be11b811daf2407d