### PR TITLE
Warn when ROI overlay skipped due to missing file

### DIFF
--- a/deeplabcut/rfid_tracking/make_video.py
+++ b/deeplabcut/rfid_tracking/make_video.py
@@ -398,13 +398,13 @@ def main(
         print(f"读取到 {len(reader_positions)} 个读卡器位置")
 
     # 加载ROI（可选）
-    rois = (
-        load_rois(cfg.ROI_FILE)
-        if (cfg.DRAW_ROIS and cfg.ROI_FILE and Path(cfg.ROI_FILE).exists())
-        else []
-    )
-    if rois:
-        print(f"加载了 {len(rois)} 个ROI区域")
+    if cfg.DRAW_ROIS and cfg.ROI_FILE and Path(cfg.ROI_FILE).exists():
+        rois = load_rois(cfg.ROI_FILE)
+        if rois:
+            print(f"加载了 {len(rois)} 个ROI区域")
+    else:
+        rois = []
+        print("ROI file not provided; skipping ROI overlay")
 
     # 打开视频
     cap = cv2.VideoCapture(video_path)


### PR DESCRIPTION
## Summary
- inform users when no ROI file is supplied so overlay is skipped

## Testing
- `pytest deeplabcut/rfid_tracking/make_video.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b10a0a7f90832285ae9f521655f954