### PR TITLE
Avoid matching gated-out ellipses

### DIFF
--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -463,10 +463,12 @@ class SORTEllipse(SORTBase):
                 for j, el_track in enumerate(ellipses_trackers):
                     dist = math.hypot(el.x - el_track.x, el.y - el_track.y)
                     if self.max_px is not None and dist > self.max_px:
-                        cost_matrix[i, j] = 0.0
+                        # Use a large negative number so the Hungarian algorithm never selects this pair
+                        cost_matrix[i, j] = -1e6
                         continue
                     if self.v_gate_pxpf is not None and dist > self.v_gate_pxpf:
-                        cost_matrix[i, j] = 0.0
+                        # Use a large negative number so the Hungarian algorithm never selects this pair
+                        cost_matrix[i, j] = -1e6
                         continue
 
                     cost = el.calc_similarity_with(el_track)

--- a/tests/test_trackingutils.py
+++ b/tests/test_trackingutils.py
@@ -75,6 +75,21 @@ def _ellipse_pose(offset):
     return base + np.asarray(offset)
 
 
+@pytest.mark.parametrize("gate_kwargs", [{"max_px": 5}, {"v_gate_pxpf": 5}])
+def test_sort_ellipse_gates_zero_iou(gate_kwargs):
+    mot_tracker = trackingutils.SORTEllipse(5, 1, 0, **gate_kwargs)
+    pose = _ellipse_pose((0, 0))[None, ...]
+    mot_tracker.track(pose)
+    far_pose = _ellipse_pose((10, 10))[None, ...]
+    ret = mot_tracker.track(far_pose)
+    assert ret.size == 0
+    assert len(mot_tracker.trackers) == 2
+    assert mot_tracker.trackers[0].time_since_update == 1
+    ret = mot_tracker.track(pose)
+    assert ret.shape[0] == 1
+    assert ret[0, -2] == 0
+
+
 def test_sort_ellipse_max_px_gate():
     mot_tracker = trackingutils.SORTEllipse(5, 1, 0.1, max_px=5)
     pose = _ellipse_pose((0, 0))[None, ...]


### PR DESCRIPTION
## Summary
- prevent SORTEllipse from associating detections beyond max/velocity gates by assigning a large negative cost
- add regression test ensuring tracks aren't matched when distance exceeds gate thresholds even with `iou_threshold=0`

## Testing
- `python -m pytest tests/test_trackingutils.py::test_sort_ellipse_gates_zero_iou tests/test_trackingutils.py::test_sort_ellipse_max_px_gate tests/test_trackingutils.py::test_sort_ellipse_v_gate_pxpf -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2dec40d308322bba1b1b2a65d972c