### PR TITLE
Add optional gating by last confirmed track position

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -1449,7 +1449,9 @@ def convert_detections2tracklets(
         Configuration file for inference (assembly of individuals). Ideally
         should be obtained from cross validation (during evaluation). By default
         the parameters are loaded from inference_cfg.yaml, but these get_level_values
-        can be overwritten.
+        can be overwritten. Additional optional keys include
+        ``gate_last_position`` to reject assignments that move far from the last
+        confirmed tracker position.
 
     calibrate: bool, optional (default=False)
         If True, use training data to calibrate the animal assembly procedure.
@@ -1521,6 +1523,7 @@ def convert_detections2tracklets(
     #   - 'px_per_cm'         : float   # pixels per centimeter
     #   - 'fps'               : float   # video frame rate
     #   - 'max_px_gate'       : float   # absolute pixel distance gate (px/frame)
+    #   - 'gate_last_position': bool    # gate assignments by last confirmed position
     # along with existing keys such as 'max_age', 'min_hits', 'iou_threshold',
     # 'oks_threshold', 'pcutoff', 'topktoretain', ...
 

--- a/deeplabcut/inference_cfg.yaml
+++ b/deeplabcut/inference_cfg.yaml
@@ -38,3 +38,5 @@ iou_threshold: .6
 max_age: 1
 # minimum number of consecutive frames before a detection is tracked
 min_hits: 1
+# whether to gate assignments by the last confirmed position
+gate_last_position: False

--- a/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
@@ -243,6 +243,7 @@ def build_tracklets(
             sd=2,
             max_px=max_px_gate,
             v_gate_pxpf=v_gate_pxpf,
+            gate_last_position=inference_cfg.get("gate_last_position", False),
         )
 
     tracklets = {}

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1473,6 +1473,7 @@ def _convert_detections_to_tracklets(
             sd=2,
             max_px=inference_cfg.get("max_px_gate"),
             v_gate_pxpf=v_gate_pxpf,
+            gate_last_position=inference_cfg.get("gate_last_position", False),
         )
     tracklets = {}
 
@@ -1774,6 +1775,7 @@ def convert_detections2tracklets(
                         sd=2,
                         max_px=inferencecfg.get("max_px_gate"),
                         v_gate_pxpf=v_gate_pxpf,
+                        gate_last_position=inferencecfg.get("gate_last_position", False),
                     )
                 tracklets = {}
                 multi_bpts = cfg["multianimalbodyparts"]

--- a/docs/maDLC_UserGuide.md
+++ b/docs/maDLC_UserGuide.md
@@ -788,6 +788,8 @@ iou_threshold: .2
 max_age: 100
 # minimum number of consecutive frames before a detection is tracked
 min_hits: 3
+# additionally gate assignments by the last confirmed tracker position
+gate_last_position: False
 ```
 
   - **IMPORTANT POINT FOR SUPERVISED IDENTITY TRACKING**


### PR DESCRIPTION
## Summary
- add `gate_last_position` option for SORTEllipse tracker and inference config
- use last confirmed position for gating when enabled
- document new parameter and test enabled/disabled cases

## Testing
- `PYTHONPATH=$PWD pytest tests/test_trackingutils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b38dd8dd388322a818c1bcd2c6c85b