### PR TITLE
Log inference configuration for RFID pipeline

### DIFF
--- a/deeplabcut/rfid_tracking/pipeline.py
+++ b/deeplabcut/rfid_tracking/pipeline.py
@@ -149,6 +149,22 @@ def run_pipeline(
     for key, val in gate_params.items():
         if val is not None:
             inference_cfg.setdefault(key, val)
+    logger.info("inference_cfg: %s", inference_cfg)
+    logger.info(
+        "Gating parameters: %s",
+        {
+            k: inference_cfg.get(k)
+            for k in (
+                "max_px_gate",
+                "velocity_gate_cms",
+                "px_per_cm",
+                "fps",
+                "gate_last_position",
+                "pcutoff",
+                "topktoretain",
+            )
+        },
+    )
 
     # 1) run inference to create assemblies without auto tracking
     logger.info(


### PR DESCRIPTION
## Summary
- log inference configuration and gating parameters loaded from project config in RFID pipeline
- supply inference configuration when converting detections to tracklets

## Testing
- `pre-commit run --files deeplabcut/rfid_tracking/pipeline.py`
- `python -m py_compile deeplabcut/rfid_tracking/pipeline.py`
- `pytest deeplabcut/rfid_tracking -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5704ac6648322bdc53aa801bb5e23