### PR TITLE
Add logging to RFID tracking scripts

### DIFF
--- a/deeplabcut/rfid_tracking/pipeline.py
+++ b/deeplabcut/rfid_tracking/pipeline.py
@@ -149,7 +149,7 @@ def run_pipeline(
     for key, val in gate_params.items():
         if val is not None:
             inference_cfg.setdefault(key, val)
-    logger.info("inference_cfg: %s", inference_cfg)
+    logger.info("Loaded inference_cfg: %s", inference_cfg)
     logger.info(
         "Gating parameters: %s",
         {

--- a/deeplabcut/rfid_tracking/scripts/run_full_pipeline.py
+++ b/deeplabcut/rfid_tracking/scripts/run_full_pipeline.py
@@ -9,8 +9,13 @@ If your model used a different shuffle index, pass it explicitly via the
 from __future__ import annotations
 
 import argparse
+import logging
 
 from deeplabcut.rfid_tracking.pipeline import run_pipeline
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def build_argparser() -> argparse.ArgumentParser:
@@ -58,6 +63,7 @@ def build_argparser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_argparser().parse_args()
+    logger.info("Arguments: %s", args)
     run_pipeline(**vars(args))
 
 

--- a/deeplabcut/rfid_tracking/scripts/run_make_video.py
+++ b/deeplabcut/rfid_tracking/scripts/run_make_video.py
@@ -4,8 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import logging
 
 from deeplabcut.rfid_tracking.make_video import main as make_video
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def build_argparser() -> argparse.ArgumentParser:
@@ -31,6 +36,7 @@ def build_argparser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_argparser().parse_args()
+    logger.info("Arguments: %s", args)
     make_video(
         video_path=args.video_path,
         pickle_path=args.pickle_path,

--- a/deeplabcut/rfid_tracking/scripts/run_match_rfid.py
+++ b/deeplabcut/rfid_tracking/scripts/run_match_rfid.py
@@ -4,9 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import logging
 
 from deeplabcut.rfid_tracking import config as cfg
 from deeplabcut.rfid_tracking.match_rfid_to_tracklets import main as match_rfid
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def build_argparser() -> argparse.ArgumentParser:
@@ -34,6 +39,7 @@ def build_argparser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_argparser().parse_args()
+    logger.info("Arguments: %s", args)
     match_rfid(
         pickle_path=args.pickle_path,
         rfid_csv=args.rfid_csv,

--- a/deeplabcut/rfid_tracking/scripts/run_reconstruct.py
+++ b/deeplabcut/rfid_tracking/scripts/run_reconstruct.py
@@ -4,8 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import logging
 
 from deeplabcut.rfid_tracking.reconstruct_from_pickle import main as reconstruct
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def build_argparser() -> argparse.ArgumentParser:
@@ -29,6 +34,7 @@ def build_argparser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_argparser().parse_args()
+    logger.info("Arguments: %s", args)
     reconstruct(
         pickle_in=args.pickle_in,
         pickle_out=args.pickle_out,


### PR DESCRIPTION
## Summary
- initialize INFO-level logging and log parsed arguments in RFID tracking CLI wrappers
- ensure run_pipeline reports the loaded inference configuration and gating parameters

## Testing
- `pytest tests/test_trackingutils.py::test_compute_v_gate_pxpf -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5746e40848322a88f0cf4fa847944