### PR TITLE
log tracker dt on match

### DIFF
--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -583,6 +583,13 @@ class SORTEllipse(SORTBase):
         for t, tracker in enumerate(self.trackers):
             if t not in unmatched_trackers:
                 ind = matches[matches[:, 1] == t, 0][0]
+                dt = tracker.time_since_update
+                logger.debug(
+                    "Accepted match for tracker %s at frame %s with dt=%s",
+                    tracker.id,
+                    self.n_frames,
+                    dt,
+                )
                 animalindex.append(ind)
                 tracker.update(ellipses[ind].parameters)
             else:


### PR DESCRIPTION
## Summary
- log each tracker's `time_since_update` when a detection match is accepted in `SORTEllipse.track`

## Testing
- `pytest tests/test_trackingutils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5888499d48322b0137a446d4b00d1