### PR TITLE
Add max_dt_for_gating to limit tracking gate relaxation

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
@@ -244,6 +244,7 @@ def build_tracklets(
             max_px_gate=max_px_gate,
             v_gate_pxpf=v_gate_pxpf,
             gate_last_position=inference_cfg.get("gate_last_position", True),
+            max_dt_for_gating=inference_cfg.get("max_dt_for_gating", 5),
         )
 
     tracklets = {}

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1474,6 +1474,7 @@ def _convert_detections_to_tracklets(
             max_px_gate=inference_cfg.get("max_px_gate"),
             v_gate_pxpf=v_gate_pxpf,
             gate_last_position=inference_cfg.get("gate_last_position", True),
+            max_dt_for_gating=inference_cfg.get("max_dt_for_gating", 5),
         )
     tracklets = {}
 
@@ -1776,6 +1777,7 @@ def convert_detections2tracklets(
                         max_px_gate=inferencecfg.get("max_px_gate"),
                         v_gate_pxpf=v_gate_pxpf,
                         gate_last_position=inferencecfg.get("gate_last_position", True),
+                        max_dt_for_gating=inferencecfg.get("max_dt_for_gating", 5),
                     )
                 tracklets = {}
                 multi_bpts = cfg["multianimalbodyparts"]

--- a/tests/test_trackingutils.py
+++ b/tests/test_trackingutils.py
@@ -117,6 +117,20 @@ def test_sort_ellipse_max_px_gate_scaled_by_dt():
     assert ret[0, -2] == 0
 
 
+def test_sort_ellipse_max_dt_for_gating():
+    mot_tracker = trackingutils.SORTEllipse(
+        20, 1, 0.0, max_px_gate=5, max_dt_for_gating=3
+    )
+    pose = _ellipse_pose((0, 0))[None, ...]
+    mot_tracker.track(pose)
+    for _ in range(10):
+        mot_tracker.track(np.empty((0, 4, 2)))
+    near_pose = _ellipse_pose((20, 0))[None, ...]
+    ret = mot_tracker.track(near_pose)
+    assert ret.size == 0
+    assert len(mot_tracker.trackers) == 2
+
+
 def test_sort_ellipse_v_gate_pxpf():
     mot_tracker = trackingutils.SORTEllipse(5, 1, 0.1, v_gate_pxpf=5)
     pose = _ellipse_pose((0, 0))[None, ...]


### PR DESCRIPTION
## Summary
- allow gating to ignore excessive `time_since_update` via new `max_dt_for_gating` knob
- expose `max_dt_for_gating` in tracking configuration for PyTorch and TensorFlow APIs
- add regression test for the cap

## Testing
- `SKIP=name-tests-test pre-commit run --files deeplabcut/core/trackingutils.py deeplabcut/pose_estimation_pytorch/apis/tracklets.py deeplabcut/pose_estimation_tensorflow/predict_videos.py tests/test_trackingutils.py`
- `PYTHONPATH=. pytest tests/test_trackingutils.py::test_sort_ellipse_max_dt_for_gating -q`
- `PYTHONPATH=. pytest tests/test_trackingutils.py::test_sort_ellipse_max_px_gate_scaled_by_dt -q`


------
https://chatgpt.com/codex/tasks/task_e_68b592633c808322b24a8768f71103a9