### PR TITLE
feat: limit ellipse tracking jumps with absolute centroid gate

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
@@ -208,6 +208,7 @@ def build_tracklets(
             inference_cfg.get("max_age", 1),
             inference_cfg.get("min_hits", 1),
             inference_cfg.get("iou_threshold", 0.6),
+            max_jump=inference_cfg.get("max_jump"),
         )
 
     tracklets = {}

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1463,6 +1463,7 @@ def _convert_detections_to_tracklets(
             inference_cfg.get("max_age", 1),
             inference_cfg.get("min_hits", 1),
             inference_cfg.get("iou_threshold", 0.6),
+            max_jump=inference_cfg.get("max_jump"),
         )
     tracklets = {}
 
@@ -1756,6 +1757,7 @@ def convert_detections2tracklets(
                         inferencecfg.get("max_age", 1),
                         inferencecfg.get("min_hits", 1),
                         inferencecfg.get("iou_threshold", 0.6),
+                        max_jump=inferencecfg.get("max_jump"),
                     )
                 tracklets = {}
                 multi_bpts = cfg["multianimalbodyparts"]

--- a/tests/test_trackingutils.py
+++ b/tests/test_trackingutils.py
@@ -63,6 +63,20 @@ def test_sort_ellipse():
     assert all(np.array_equal(tracklets[n][0], pose) for n, pose in enumerate(poses))
 
 
+def test_sort_ellipse_max_jump():
+    base = np.asarray(
+        [[0, 0], [1, 0], [-1, 0], [0, 1], [0, -1], [1, 1]], dtype=float
+    )
+    mot_tracker = trackingutils.SORTEllipse(1, 1, 0.1, max_jump=10)
+    mot_tracker.track(base[None])
+    mot_tracker.track((base + np.array([1, 0]))[None])
+    assert len(mot_tracker.trackers) == 1
+    mot_tracker = trackingutils.SORTEllipse(1, 1, 0.1, max_jump=10)
+    mot_tracker.track(base[None])
+    mot_tracker.track((base + np.array([100, 0]))[None])
+    assert len(mot_tracker.trackers) == 2
+
+
 def test_tracking_ellipse(real_assemblies, real_tracklets):
     tracklets_ref = real_tracklets.copy()
     _ = tracklets_ref.pop("header", None)


### PR DESCRIPTION
## Summary
- add optional `max_jump` threshold to `SORTEllipse` that rejects matches with large centroid displacement
- plumb `max_jump` through TensorFlow and PyTorch video prediction pipelines
- test that large jumps spawn new tracklets

## Testing
- `pytest tests/test_trackingutils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2069f208322ad20cb1ca4c48928