### PR TITLE
Add centroid fallback when ellipse fit fails in SORTEllipse

### DIFF
--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -489,6 +489,10 @@ class SORTEllipse(SORTBase):
         ellipses, pred_ids = [], []
         for i, pose in enumerate(poses):
             el = self.fitter.fit(pose)
+            if el is None:
+                center = np.nanmean(pose, axis=0)
+                if np.isfinite(center).all():
+                    el = Ellipse(center[0], center[1], 1.0, 1.0, 0.0)
             if el is not None:
                 ellipses.append(el)
                 if identities is not None:

--- a/tests/test_trackingutils.py
+++ b/tests/test_trackingutils.py
@@ -155,6 +155,16 @@ def test_sort_ellipse_v_gate_pxpf():
     assert ret[0, -2] == 0
 
 
+def test_sort_ellipse_fallback_center():
+    mot_tracker = trackingutils.SORTEllipse(5, 1, 0.1, max_px_gate=5)
+    pose = _ellipse_pose((0, 0))[None, ...]
+    mot_tracker.track(pose)
+    far_pose = np.array([[[200.0, 0.0], [200.0, 0.0], [np.nan, np.nan], [np.nan, np.nan]]])
+    ret = mot_tracker.track(far_pose)
+    assert ret.size == 0
+    assert len(mot_tracker.trackers) == 2
+
+
 @pytest.mark.parametrize("gate_key", ["max_px_gate", "v_gate_pxpf"])
 @pytest.mark.parametrize("gate_last_position", [None, False, True])
 def test_sort_ellipse_rejects_large_displacement(gate_key, gate_last_position):


### PR DESCRIPTION
## Summary
- fallback to keypoint centroid when ellipse fitting fails
- test that fallback gating rejects large jumps

## Testing
- `pytest tests/test_trackingutils.py` *(fails: No module named 'deeplabcut')*


------
https://chatgpt.com/codex/tasks/task_e_68b5cc267e9083228ab43dfc5e831f94