### PR TITLE
feat: gate SORTEllipse detections by centroid

### DIFF
--- a/tests/test_trackingutils.py
+++ b/tests/test_trackingutils.py
@@ -49,10 +49,11 @@ def test_ellipse_fitter():
 
 
 def test_ellipse_tracker(ellipse):
-    tracker1 = trackingutils.EllipseTracker(ellipse.parameters)
-    tracker2 = trackingutils.EllipseTracker(ellipse.parameters)
+    centroid = (ellipse.x, ellipse.y)
+    tracker1 = trackingutils.EllipseTracker(ellipse.parameters, centroid)
+    tracker2 = trackingutils.EllipseTracker(ellipse.parameters, centroid)
     assert tracker1.id != tracker2.id
-    tracker1.update(ellipse.parameters)
+    tracker1.update(ellipse.parameters, centroid)
     assert tracker1.hit_streak == 1
     state = tracker1.predict()
     np.testing.assert_equal(ellipse.parameters, state)


### PR DESCRIPTION
## Summary
- compute keypoint centroid for each pose and store in EllipseTracker
- gate detections based on centroid displacement before computing cost matrix
- update unit tests for centroid-aware tracker API

## Testing
- `PYTHONPATH=$PWD pytest tests/test_trackingutils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5fb4e4ae4832298e532f9f2d39c2d