### PR TITLE
Handle NaN centroids in EllipseTracker

### DIFF
--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -312,11 +312,18 @@ class EllipseTracker(BaseTracker):
         performed using the last confirmed position. The centroid of the
         observation is also stored for future distance gating.
         """
+        centroid = np.asarray(centroid)
+        if np.isnan(centroid).any():
+            # Update the Kalman filter state without confirming the centroid.
+            self.kf.update(np.asarray(params))
+            self.time_since_update += 1
+            return
+
         super().update(np.asarray(params))
         # After a successful update, synchronise the last confirmed state and
         # centroid.
         self.last_confirmed_state = self.state.copy()
-        self.last_confirmed_centroid = np.asarray(centroid).copy()
+        self.last_confirmed_centroid = centroid.copy()
 
 
 class SkeletonTracker(BaseTracker):

--- a/tests/trackingutils_test.py
+++ b/tests/trackingutils_test.py
@@ -61,6 +61,18 @@ def test_ellipse_tracker(ellipse):
     assert tracker1.hit_streak == 0
 
 
+def test_ellipse_tracker_nan_centroid(ellipse):
+    centroid = (ellipse.x, ellipse.y)
+    tracker = trackingutils.EllipseTracker(ellipse.parameters, centroid)
+    tracker.update(ellipse.parameters, centroid)
+    prev_state = tracker.last_confirmed_state.copy()
+    prev_centroid = tracker.last_confirmed_centroid.copy()
+    tracker.update(ellipse.parameters, (np.nan, centroid[1]))
+    assert tracker.time_since_update == 1
+    np.testing.assert_array_equal(tracker.last_confirmed_state, prev_state)
+    np.testing.assert_array_equal(tracker.last_confirmed_centroid, prev_centroid)
+
+
 def test_sort_ellipse():
     tracklets = dict()
     mot_tracker = trackingutils.SORTEllipse(1, 1, 0.6)


### PR DESCRIPTION
## Summary
- skip updating `last_confirmed_centroid` when `EllipseTracker.update` receives a NaN centroid
- cover NaN centroid handling with tests and rename test file to conform to naming hook

## Testing
- `pre-commit run --files deeplabcut/core/trackingutils.py tests/trackingutils_test.py`
- `PYTHONPATH=$PWD pytest tests/trackingutils_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b605c97da4832296f4db2c7ce215e5