### PR TITLE
Log tracking break reasons and report generation

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1520,7 +1520,8 @@ def _convert_detections_to_tracklets(
             )  # TODO: get cropping parameters and utilize!
         else:
             xy = animals[..., :2]
-        trackers = mot_tracker.track(xy)
+        track_out = mot_tracker.track(xy)
+        trackers = track_out[0] if isinstance(track_out, tuple) else track_out
         trackingutils.fill_tracklets(tracklets, trackers, animals, imname)
 
     bodypartlabels = [joint for joint in joints for _ in range(3)]
@@ -1852,7 +1853,8 @@ def convert_detections2tracklets(
                                 )  # TODO: get cropping parameters and utilize!
                             else:
                                 xy = animals[:, keep_inds, :2]
-                            trackers = mot_tracker.track(xy)
+                            track_out = mot_tracker.track(xy)
+                            trackers = track_out[0] if isinstance(track_out, tuple) else track_out
                         else:
                             # Optimal identity assignment based on soft voting
                             mat = np.zeros(

--- a/deeplabcut/rfid_tracking/convert_detection2tracklets.py
+++ b/deeplabcut/rfid_tracking/convert_detection2tracklets.py
@@ -108,7 +108,7 @@ def main(
         f"velocity_gate_cms={velocity_gate_cms}, px_per_cm={px_per_cm}, fps={fps}"
     )
 
-    dlc.convert_detections2tracklets(
+    reports = dlc.convert_detections2tracklets(
         config=config_path,
         videos=videos,
         videotype=videotype,
@@ -117,8 +117,9 @@ def main(
         destfolder=destfolder,
         inferencecfg=base_inferencecfg,
     )
-
     print("\n[OK] 完成。请在对应输出目录查看 *.pickle（tracklets）文件。")
+    for path in reports or []:
+        print(f"[INFO] tracklet report: {path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track SORTEllipse break events (`all_nan`, `gated`, `max_age`) and expose via return value
- collect break logs in `build_tracklets` and write per-video JSON reports
- surface report paths in convert_detection2tracklets CLI

## Testing
- `PYTHONPATH=$PWD pytest tests/test_trackingutils.py tests/pose_estimation_pytorch/apis/test_tracklets.py` *(fails: assert 87 == 3)*

------
https://chatgpt.com/codex/tasks/task_e_68b6618f9a9c83229d72625854d0cebd