### PR TITLE
Skip non-dictionary entries when iterating tracklet data

### DIFF
--- a/deeplabcut/rfid_tracking/match_rfid_to_tracklets.py
+++ b/deeplabcut/rfid_tracking/match_rfid_to_tracklets.py
@@ -519,7 +519,7 @@ def main(
     ] = defaultdict(list)
     valid_frame_count: dict[object, int] = defaultdict(int)
     for tk, node in dd.items():
-        if tk in ("header", "single"):
+        if tk in ("header", "single") or not isinstance(node, dict):
             continue
         for fkey, arr in node.items():
             try:


### PR DESCRIPTION
## Summary
- Avoid errors in `match_rfid_to_tracklets` by skipping any tracklet entries that are not dictionaries

## Testing
- `pytest -q deeplabcut/rfid_tracking`


------
https://chatgpt.com/codex/tasks/task_e_68b685aa0af883228e0321a6d49e92ea