### PR TITLE
Switch tracklet reports to CSV

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
@@ -8,7 +8,6 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-import json
 import logging
 import os
 import pickle
@@ -160,7 +159,7 @@ def convert_detections2tracklets(
                 )
             assemblies_data = auxiliaryfunctions.read_pickle(assemblies_path)
 
-            report_path = output_path / f"{video_name}_tracklet_report.json"
+            report_path = output_path / f"{video_name}_tracklet_report.csv"
             tracklets = build_tracklets(
                 assemblies_data=assemblies_data,
                 track_method=track_method,
@@ -358,8 +357,8 @@ def build_tracklets(
                         "break_reason": ev["reason"],
                     }
                 )
-        with open(report_path, "w") as f:
-            json.dump(report, f)
+        if report_path is not None:
+            pd.DataFrame(report).to_csv(report_path, index=False)
 
     return tracklets
 

--- a/tests/pose_estimation_pytorch/apis/test_tracklets.py
+++ b/tests/pose_estimation_pytorch/apis/test_tracklets.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from deeplabcut.core import trackingutils
 from deeplabcut.pose_estimation_pytorch.apis.tracklets import build_tracklets
 
 
@@ -98,3 +99,35 @@ def test_build_tracklets(
         assert not "single" in tracklets
 
     assert isinstance(tracklets, dict)
+
+
+def test_build_tracklets_report_csv(tmp_path, monkeypatch):
+    class DummySORTBox(trackingutils.SORTBox):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.break_log = {0: [{"frame": 0, "reason": "dummy"}]}
+
+    monkeypatch.setattr(trackingutils, "SORTBox", DummySORTBox)
+
+    report_path = tmp_path / "report.csv"
+    assemblies_data = {0: [np.array([[10, 20, 0.9, -1], [30, 40, 0.8, -1]])]}
+    build_tracklets(
+        assemblies_data=assemblies_data,
+        track_method="box",
+        inference_cfg={"max_age": 3, "min_hits": 1, "topktoretain": 1, "pcutoff": 0.5},
+        joints=["nose", "ear"],
+        scorer="DLC",
+        num_frames=1,
+        report_path=report_path,
+    )
+
+    df = pd.read_csv(report_path)
+    assert list(df.columns) == [
+        "tracklet_id",
+        "start_frame",
+        "end_frame",
+        "break_reason",
+    ]
+    assert len(df) == 1
+    assert df.loc[0, "tracklet_id"] == 0
+    assert df.loc[0, "break_reason"] == "dummy"


### PR DESCRIPTION
## Summary
- output tracklet break reports as CSV files
- store break logs to CSV instead of JSON
- add test to ensure CSV report structure

## Testing
- `PYTHONPATH=. pytest tests/pose_estimation_pytorch/apis/test_tracklets.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b689df29fc83229516d6e0ea84263b