### PR TITLE
Record detection indices in tracking break reports

### DIFF
--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -673,18 +673,22 @@ class SORTEllipse(SORTBase):
 
         if not len(ellipses):
             for trk in self.trackers:
-                event = {"frame": self.n_frames, "reason": "all_nan"}
+                event = {"frame": self.n_frames, "reason": "all_nan", "assembly": -1}
                 self.break_log[trk.id].append(event)
                 frame_breaks.append((trk.id, event))
         else:
             for idx in unmatched_trackers:
                 trk = self.trackers[idx]
                 if trk.id in gated_trackers:
-                    event = {"frame": self.n_frames, "reason": "gated"}
+                    event = {"frame": self.n_frames, "reason": "gated", "assembly": -1}
                     self.break_log[trk.id].append(event)
                     frame_breaks.append((trk.id, event))
                 else:
-                    event = {"frame": self.n_frames, "reason": "iou_fail"}
+                    event = {
+                        "frame": self.n_frames,
+                        "reason": "iou_fail",
+                        "assembly": -1,
+                    }
                     self.break_log[trk.id].append(event)
                     frame_breaks.append((trk.id, event))
 
@@ -746,7 +750,12 @@ class SORTEllipse(SORTBase):
                 )
             i -= 1
             if trk.time_since_update > self.max_age:
-                event = {"frame": self.n_frames, "reason": "max_age"}
+                det_idx = int(animalindex[i]) if i < len(animalindex) else -1
+                event = {
+                    "frame": self.n_frames,
+                    "reason": "max_age",
+                    "assembly": det_idx,
+                }
                 self.break_log[trk.id].append(event)
                 frame_breaks.append((trk.id, event))
                 self.trackers.pop(i)

--- a/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
@@ -344,7 +344,8 @@ def build_tracklets(
             frames = []
             if tid in tracklets:
                 frames = [
-                    int(str(k).replace("frame", "")) for k in tracklets[tid].keys()
+                    int(str(k).replace("frame", ""))
+                    for k in tracklets[tid].keys()
                     if str(k).startswith("frame")
                 ]
             start_frame = min(frames) if frames else None
@@ -355,6 +356,7 @@ def build_tracklets(
                         "start_frame": start_frame,
                         "end_frame": ev["frame"],
                         "break_reason": ev["reason"],
+                        "assembly": ev.get("assembly", -1),
                     }
                 )
         if report_path is not None:

--- a/tests/pose_estimation_pytorch/apis/test_tracklets.py
+++ b/tests/pose_estimation_pytorch/apis/test_tracklets.py
@@ -105,7 +105,7 @@ def test_build_tracklets_report_csv(tmp_path, monkeypatch):
     class DummySORTBox(trackingutils.SORTBox):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.break_log = {0: [{"frame": 0, "reason": "dummy"}]}
+            self.break_log = {0: [{"frame": 0, "reason": "dummy", "assembly": -1}]}
 
     monkeypatch.setattr(trackingutils, "SORTBox", DummySORTBox)
 
@@ -127,7 +127,9 @@ def test_build_tracklets_report_csv(tmp_path, monkeypatch):
         "start_frame",
         "end_frame",
         "break_reason",
+        "assembly",
     ]
     assert len(df) == 1
     assert df.loc[0, "tracklet_id"] == 0
     assert df.loc[0, "break_reason"] == "dummy"
+    assert df.loc[0, "assembly"] == -1


### PR DESCRIPTION
## Summary
- include `assembly` detection index in SORTEllipse break logs and frame break events
- export `assembly` field in tracklet break reports
- extend tests to cover new report column

## Testing
- `SKIP=name-tests-test PYTHONPATH=$PWD:$PYTHONPATH pytest tests/test_trackingutils.py::test_sort_ellipse_logs_iou_fail tests/pose_estimation_pytorch/apis/test_tracklets.py::test_build_tracklets_report_csv -q`
- `PYTHONPATH=$PWD:$PYTHONPATH pytest tests/test_trackingutils.py tests/pose_estimation_pytorch/apis/test_tracklets.py -q` *(fails: assert 87 == 3 in tests/test_trackingutils.py::test_tracking_box)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a4d1734c832289f0edda4cba3ec7