### PR TITLE
Support frame_number timestamps column

### DIFF
--- a/deeplabcut/rfid_tracking/match_rfid_to_tracklets.py
+++ b/deeplabcut/rfid_tracking/match_rfid_to_tracklets.py
@@ -209,11 +209,12 @@ def parse_timestamps_csv(ts_path: str) -> tuple[np.ndarray, np.ndarray]:
     df = pd.read_csv(ts_path)
     cols = {c.lower(): c for c in df.columns}
 
-    frame_k = next(
-        (cols.get(k) for k in ["frame", "frame_id", "fid", "index"] if k in cols), None
-    )
+    frame_keys = ["frame", "frame_id", "fid", "index", "frame_number"]
+    frame_k = next((cols.get(k) for k in frame_keys if k in cols), None)
     if frame_k is None:
-        raise ValueError("timestamps.csv 未找到帧列（frame/frame_id/fid/index）")
+        raise ValueError(
+            f"timestamps.csv 未找到帧列（{'/'.join(frame_keys)}）"
+        )
 
     time_keys = [
         "time",

--- a/tests/test_rfid_tracking.py
+++ b/tests/test_rfid_tracking.py
@@ -43,7 +43,7 @@ def test_resume_after_partial_pickle(tmp_path):
     _write_simple_csv(rfid_csv, "time,tag,id", ["0,A,0", "1,A,0"])
 
     ts_csv = tmp_path / "timestamps.csv"
-    _write_simple_csv(ts_csv, "frame,time", ["0,0", "1,1"])
+    _write_simple_csv(ts_csv, "frame_number,time", ["0,0", "1,1"])
 
     pickle_path = tmp_path / "tracklets.pickle"
     dd = {


### PR DESCRIPTION
## Summary
- allow `parse_timestamps_csv` to recognize `frame_number` columns and surface all accepted aliases in the error message
- adjust the RFID tracking test fixture to use a timestamps CSV with the new alias

## Testing
- `python - <<'PY' ...` (runs RFID matching pipeline with a timestamps CSV containing the `frame_number` column)


------
https://chatgpt.com/codex/tasks/task_e_68cbae866dfc8322a8eb70ae0a6aa1b8